### PR TITLE
feat(ui): add configurable window options

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ require("mcphub").setup({
         zindex = 50,
         border = "rounded", -- "none", "single", "double", "rounded", "solid", "shadow"
       },
+      wo = { -- window-scoped options (vim.wo)
+      }
     },
 
     -- Event callbacks

--- a/doc/mcphub.txt
+++ b/doc/mcphub.txt
@@ -115,6 +115,9 @@ Advanced Configuration: >lua
             zindex = 50,
             border = "rounded", -- "none", "single", "double", "rounded", "solid", "shadow"
           },
+          wo = { -- window-scoped options (vim.wo)
+              winhl = "Normal:" .. hl.groups.window_normal .. ",FloatBorder:" .. hl.groups.window_border,
+          },
         },
 
         -- Event callbacks

--- a/lua/mcphub/ui/init.lua
+++ b/lua/mcphub/ui/init.lua
@@ -20,6 +20,9 @@ UI.defaults = {
         relative = "editor",
         zindex = 50,
     },
+    wo = { -- window-scoped options (vim.wo)
+        winhl = "Normal:" .. hl.groups.window_normal .. ",FloatBorder:" .. hl.groups.window_border,
+    },
 }
 
 -- User configured options
@@ -197,12 +200,9 @@ function UI:create_window()
         zindex = win_opts.zindex,
     })
 
-    -- Apply window highlights
-    vim.api.nvim_win_set_option(
-        self.window,
-        "winhl",
-        "Normal:" .. hl.groups.window_normal .. ",FloatBorder:" .. hl.groups.window_border
-    )
+    for k, v in pairs(UI.opts.wo or {}) do
+        vim.api.nvim_set_option_value(k, v, { scope = "local", win = self.window })
+    end
 
     return self.window
 end


### PR DESCRIPTION
Hello,

I would like to add the ability to configure window options (vim.wo) for the MCPHup window.

I'm currently using this to remove predefined window highlights and use winblend:
```lua
opts = {
  ui = {
     wo = {
      winblend = vim.o.winblend,
      winhl = '',
    },
  },
}
```