### PR TITLE
feat: added better support for windows (fixes #69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,23 +263,12 @@ require("mcphub").setup({
     end,
 
     --set this to true when using build = "bundled_build.lua"
-    use_bundled_binary = false, -- Uses bundled mcp-hub instead of global installation
+    use_bundled_binary = false, -- Uses bundled mcp-hub script instead of global installation
 
     --WARN: Use the custom setup if you can't use `npm install -g mcp-hub` or cant have `build = "bundled_build.lua"`
     -- Custom Server command configuration
     --cmd = "node", -- The command to invoke the MCP Hub Server
     --cmdArgs = {"/path/to/node_modules/mcp-hub/dist/cli.js"},    -- Additional arguments for the command
-
-    -- Common command configurations (when not using bundled binary):
-    -- 1. Global installation (default):
-    --   cmd = "mcp-hub"
-    --   cmdArgs = {}
-    -- 2. Local npm package:
-    --   cmd = "node"
-    --   cmdArgs = {"/path/to/node_modules/mcp-hub/dist/cli.js"}
-    -- 3. Custom binary:
-    --   cmd = "/usr/local/bin/custom-mcp-hub"
-    --   cmdArgs = {"--custom-flag"}
 
     -- Logging configuration
     log = {

--- a/lua/mcphub/hub.lua
+++ b/lua/mcphub/hub.lua
@@ -93,7 +93,7 @@ function MCPHub:start(opts, restart_callback)
         self.server_job = Job:new({
             command = self.cmd,
             args = utils.clean_args({ self.cmdArgs, "--port", tostring(self.port), "--config", self.config }),
-            detached = true,
+            -- detached = true,
             on_stdout = vim.schedule_wrap(function(_, data)
                 if has_called_restart_callback == false then
                     if restart_callback then
@@ -1189,7 +1189,7 @@ function MCPHub:get_marketplace_server_details(mcpId, opts)
                     { mcpId = mcpId, error = err }
                 )
                 State:add_error(market_err)
-                -- Keep server details as nil to indicate error state
+            -- Keep server details as nil to indicate error state
             else
                 -- Update state with new details
                 State:update({

--- a/lua/mcphub/init.lua
+++ b/lua/mcphub/init.lua
@@ -37,8 +37,8 @@ function M.setup(opts)
         native_servers = {},
         auto_approve = false,
         use_bundled_binary = false, -- Whether to use bundled mcp-hub binary
-        cmd = "mcp-hub",
-        cmdArgs = {},
+        cmd = nil, -- will be set based on system if not provided
+        cmdArgs = nil, -- will be set based on system if not provided
         log = {
             level = vim.log.levels.ERROR,
             to_file = false,
@@ -69,11 +69,9 @@ function M.setup(opts)
         on_error = function(str) end,
     }, opts or {})
 
-    -- Override cmd if using bundled binary
-    if config.use_bundled_binary then
-        config.cmd = utils.get_bundled_mcp_path()
-    end
-
+    local cmds = utils.get_default_cmds(config)
+    config.cmd = cmds.cmd
+    config.cmdArgs = cmds.cmdArgs
     if config.auto_approve then
         vim.g.mcphub_auto_approve = vim.g.mcphub_auto_approve == nil and true or vim.g.mcphub_auto_approve
     end


### PR DESCRIPTION
- Fixes console window opening with `mcp-hub`
- Uses mcp-hub.cmd instead of `mcp-hub` on windows