### PR TITLE
feat(codecompanion): auto submit MCP results

### DIFF
--- a/lua/mcphub/extensions/codecompanion.lua
+++ b/lua/mcphub/extensions/codecompanion.lua
@@ -295,6 +295,8 @@ The Model Context Protocol (MCP) enables communication with locally running MCP 
             --     end, result.images),
             -- }, { visible = false })
             -- end
+
+            self.chat:submit()
         end,
     },
 }


### PR DESCRIPTION
Currently, codecompanion requires manual submission of the MCP tool result.

This PR make it automatic to aline with avante integration and Calude Desktop.