### PR TITLE
Fix system prompt from CodeCompanion extension

### DIFF
--- a/lua/mcphub/extensions/codecompanion.lua
+++ b/lua/mcphub/extensions/codecompanion.lua
@@ -141,8 +141,12 @@ local tool_schema = {
     },
 
     system_prompt = function(schema)
-        -- get the running hub instance
-        local hub = require("mcphub").get_hub_instance()
+        local prompts = require("mcphub").get_hub_instance():generate_prompts({
+            add_example = false,
+            use_mcp_tool_example = xml2lua.toXml({ tools = { schema[1] } }),
+            access_mcp_resource_example = xml2lua.toXml({ tools = { schema[2] } }),
+        })
+
         return string.format(
             [[### MCP Tool
 
@@ -205,13 +209,9 @@ The Model Context Protocol (MCP) enables communication with locally running MCP 
 
 %s]],
             '<![CDATA[{"city": "San Francisco", "days": 5}]]>',
-            hub:get_use_mcp_tool_prompt(xml2lua.toXml({
-                tools = { schema[1] },
-            })), -- gets the prompt for the use_mcp_tool action
-            hub:get_access_mcp_resource_prompt(xml2lua.toXml({
-                tools = { schema[2] },
-            })), -- gets the prompt for the access_mcp_resource action
-            hub:get_active_servers_prompt(false) -- generates prompt from currently running mcp servers
+            prompts.use_mcp_tool,
+            prompts.access_mcp_resource,
+            prompts.active_servers
         )
     end,
     output = {


### PR DESCRIPTION
Hi! 👋 

I started to get the following error when calling the `@mcp` tool on CodeCompanion:

```
E5108: Error executing lua: ...lazy/mcphub.nvim/lua/mcphub/extensions/codecompanion.lua:208: attempt to call method 'get_use_mcp_tool_prompt' (a nil value)
stack traceback:
        ...lazy/mcphub.nvim/lua/mcphub/extensions/codecompanion.lua:208: in function 'system_prompt'
        ...ompanion.nvim/lua/codecompanion/strategies/chat/init.lua:633: in function 'add_tool'
        ...n.nvim/lua/codecompanion/strategies/chat/agents/init.lua:280: in function 'parse'
        ...ompanion.nvim/lua/codecompanion/strategies/chat/init.lua:673: in function 'apply_tools_and_variables'
        ...ompanion.nvim/lua/codecompanion/strategies/chat/init.lua:728: in function 'submit'
        ...anion.nvim/lua/codecompanion/strategies/chat/keymaps.lua:216: in function 'rhs'
        ...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:80: in function <...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:77>
```

I've noticed that `get_use_mcp_tool_prompt` and `get_access_mcp_resource_prompt` were removed on the [a46a9c7
](https://github.com/ravitemer/mcphub.nvim/commit/a46a9c78a1c83eab2e70f904f1c3966f3e3488e1#diff-8889bd39500269b2f94a7f8fbd0c4c3b3d8ba726be76c8c84000aeeecd0e0510) commit, but I didn't understand why. Maybe they were removed by accident? Anyway, adding the methods back fixed the issue. However, I refactored the code a bit to use `generate_prompts` instead of re-adding the methods because it seemed to be the best approach.

I assume this won't impact the multi-neovim support (added in the [a46a9c7](https://github.com/ravitemer/mcphub.nvim/commit/a46a9c78a1c83eab2e70f904f1c3966f3e3488e1#diff-8889bd39500269b2f94a7f8fbd0c4c3b3d8ba726be76c8c84000aeeecd0e0510) commit) with CodeCompanion, but let me know if that's not the case.