### PR TITLE
refactor: convert environment description from function to string

### DIFF
--- a/lua/mcphub/native/neovim/files/environment.lua
+++ b/lua/mcphub/native/neovim/files/environment.lua
@@ -3,9 +3,7 @@ local os_utils = require("mcphub.native.neovim.utils.os")
 
 return {
     name = "Environment",
-    description = function()
-        return "This resource gives comprehensive information about the workspace, editor and OS. Includes directory structure, visible and loaded buffers along with the OS information."
-    end,
+    description = "This resource gives comprehensive information about the workspace, editor and OS. Includes directory structure, visible and loaded buffers along with the OS information.",
     uri = "neovim://workspace/info",
     mimeType = "text/plain",
     handler = function(req, res)


### PR DESCRIPTION
It was function for no reason really looks like and nothing else is using function as description value.

As side note, as hub.lua is missing proper type annotations this was quite confusing design choice in first place as its very easy to run into.