### PR TITLE
fix(highlights): don't override existing definitions

### DIFF
--- a/lua/mcphub/utils/highlights.lua
+++ b/lua/mcphub/utils/highlights.lua
@@ -216,6 +216,7 @@ function M.setup()
 
     -- Set highlights
     for name, val in pairs(highlights) do
+        val.default = true
         vim.api.nvim_set_hl(0, name, val)
     end
 end


### PR DESCRIPTION
## Description

The current use of `nvim_set_hl` will override any MCPHub.nvim highlight groups that have been set by external sources such as themes or a user's config. This occurs when MCPHub.nvim is loaded first.

As per the vim docs:

```
nvim_set_hl({ns_id}, {name}, {val})                            *nvim_set_hl()*
    Sets a highlight group.

    Note: ~
      • Unlike the `:highlight` command which can update a highlight group,
        this function completely replaces the definition. For example:
        `nvim_set_hl(0, 'Visual', {})` will clear the highlight group
        'Visual'.
      • The fg and bg keys also accept the string values `"fg"` or `"bg"`
        which act as aliases to the corresponding foreground and background
        values of the Normal group. If the Normal group has not been defined,
        using these values results in an error.
      • If `link` is used in combination with other attributes; only the
        `link` will take effect (see |:hi-link|).

    Attributes: ~
        Since: 0.5.0

    Parameters: ~
      • {ns_id}  Namespace id for this highlight |nvim_create_namespace()|.
                 Use 0 to set a highlight group globally |:highlight|.
                 Highlights from non-global namespaces are not active by
                 default, use |nvim_set_hl_ns()| or |nvim_win_set_hl_ns()| to
                 activate them.
      • {name}   Highlight group name, e.g. "ErrorMsg"
      • {val}    Highlight definition map, accepts the following keys:
                 • fg: color name or "#RRGGBB", see note.
                 • bg: color name or "#RRGGBB", see note.
                 • sp: color name or "#RRGGBB"
                 • blend: integer between 0 and 100
                 • bold: boolean
                 • standout: boolean
                 • underline: boolean
                 • undercurl: boolean
                 • underdouble: boolean
                 • underdotted: boolean
                 • underdashed: boolean
                 • strikethrough: boolean
                 • italic: boolean
                 • reverse: boolean
                 • nocombine: boolean
                 • link: name of another highlight group to link to, see
                   |:hi-link|.
                 • default: Don't override existing definition |:hi-default|
                 • ctermfg: Sets foreground of cterm color |ctermfg|
                 • ctermbg: Sets background of cterm color |ctermbg|
                 • cterm: cterm attribute map, like |highlight-args|. If not
                   set, cterm attributes will match those from the attribute
                   map documented above.
                 • force: if true force update the highlight group when it
```

This will allow me to add direct support for MCPHub.nvim in my colorscheme.

## Checklist

- [X] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [X] I've run `make test` to ensure all tests pass
- [X] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
