### PR TITLE
refactor: format output messages

### DIFF
--- a/lua/mcphub/extensions/codecompanion/utils.lua
+++ b/lua/mcphub/extensions/codecompanion/utils.lua
@@ -111,10 +111,13 @@ function M.create_output_handlers(action_name, has_function_calling, opts)
                 stderr = vim.inspect(stderr)
             end
             local err_msg = string.format(
-                [[ERROR: The `%s` call failed with the following error:
+                [[**`%s` Tool**: Failed with the following error:
+
+```                
 <error>
 %s
 </error>
+```
 ]],
                 action_name,
                 stderr
@@ -128,8 +131,11 @@ function M.create_output_handlers(action_name, has_function_calling, opts)
             -- TODO: add messages with role = `tool` when supported
             if result.text and result.text ~= "" then
                 local to_llm = string.format(
-                    [[The `%s` call returned the following text:
-%s]],
+                    [[**`%s` Tool**: Returned the following:
+
+```
+%s
+```]],
                     action_name,
                     result.text
                 )


### PR DESCRIPTION
## Description

Feel free to discard this btw - I'm not precious and this is your wonderful piece of work.

I've styled all CodeCompanion's tools to use bolds for the tool name and then a brief description of the output, followed by the output itself. If we wrap the output in a codeblock then we can use `gy` to copy it.

Btw, I haven't tested this but just mocked up what the output should look like in CodeCompanion.

## Related Issue(s)

N/A

## Screenshots

![2025-04-30 23_25_21 - WezTerm@2x](https://github.com/user-attachments/assets/0026bfaf-300a-4c43-ac22-60b090bc57d1)

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make test` to ensure all tests pass
- [ ] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
