### PR TITLE
feat: replace confirm with select when delete server

### DIFF
--- a/lua/mcphub/ui/views/main.lua
+++ b/lua/mcphub/ui/views/main.lua
@@ -231,21 +231,19 @@ function MainView:handle_delete()
         if is_native then
             return vim.notify("Native servers cannot be deleted")
         end
-        
+
         -- Using vim.ui.select instead of vim.fn.confirm
-        vim.ui.select(
-            { "Yes", "No" },
-            {
-                prompt = "Are you sure you want to delete " .. server_name .. "?",
-                format_item = function(item) return item end,
-            },
-            function(choice)
-                if choice == "Yes" then
-                    State.hub_instance:remove_server_config(server_name)
-                    vim.notify("Server " .. server_name .. " deleted", vim.log.levels.INFO)
-                end
+        vim.ui.select({ "Yes", "No" }, {
+            prompt = "Are you sure you want to delete " .. server_name .. "?",
+            format_item = function(item)
+                return item
+            end,
+        }, function(choice)
+            if choice == "Yes" then
+                State.hub_instance:remove_server_config(server_name)
+                vim.notify("Server " .. server_name .. " deleted", vim.log.levels.INFO)
             end
-        )
+        end)
     end
 end
 

--- a/lua/mcphub/ui/views/main.lua
+++ b/lua/mcphub/ui/views/main.lua
@@ -231,12 +231,21 @@ function MainView:handle_delete()
         if is_native then
             return vim.notify("Native servers cannot be deleted")
         end
-        --confirm deletion
-        local confirm = vim.fn.confirm("Are you sure you want to delete " .. server_name .. "?", "&Yes\n&No", 2)
-        if confirm == 1 then
-            State.hub_instance:remove_server_config(server_name)
-            vim.notify("Server " .. server_name .. " deleted", vim.log.levels.INFO)
-        end
+        
+        -- Using vim.ui.select instead of vim.fn.confirm
+        vim.ui.select(
+            { "Yes", "No" },
+            {
+                prompt = "Are you sure you want to delete " .. server_name .. "?",
+                format_item = function(item) return item end,
+            },
+            function(choice)
+                if choice == "Yes" then
+                    State.hub_instance:remove_server_config(server_name)
+                    vim.notify("Server " .. server_name .. " deleted", vim.log.levels.INFO)
+                end
+            end
+        )
     end
 end
 


### PR DESCRIPTION
## Description

replace confirm with select when delete server

## Screenshots

This UI is with `snack.nvim`

![image](https://github.com/user-attachments/assets/8d3fa727-38da-42b7-a0c5-1b14792e1088)

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ ] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
