### PR TITLE
Small fixes to first time config creation

### DIFF
--- a/doc/mcphub.txt
+++ b/doc/mcphub.txt
@@ -1,4 +1,4 @@
-*mcphub.nvim.txt*          For NVIM v0.10.0         Last change: 2025 April 29
+*mcphub.nvim.txt*           For NVIM v0.10.0          Last change: 2025 May 03
 
 ==============================================================================
 Table of Contents                              *mcphub.nvim-table-of-contents*

--- a/lua/mcphub/utils/validation.lua
+++ b/lua/mcphub/utils/validation.lua
@@ -207,11 +207,18 @@ function M.validate_config_file(path)
     end
     local file = io.open(path, "r")
     if not file then
-        -- File doesn't exist or can't be opened for reading.  Attempt to create it with default content.
+        -- File doesn't exist or can't be opened for reading. Attempt to create it with default content.
+
+        -- Ensure parent directory exists
+        local dir_path = vim.fn.fnamemodify(path, ":h")
+        if vim.fn.isdirectory(dir_path) == 0 then
+            vim.fn.mkdir(dir_path, "p")
+        end
+
         local create_file, create_err = io.open(path, "w")
 
         if not create_file then
-            -- Creation failed.  Return an error.
+            -- Creation failed. Return an error.
             return {
                 ok = false,
                 error = Error(
@@ -398,6 +405,7 @@ function M.validate_config_file(path)
         content = content,
     }
 end
+
 --- Validate MCP Hub version
 ---@param ver_str string Version string to validate
 ---@return ValidationResult

--- a/lua/mcphub/utils/validation.lua
+++ b/lua/mcphub/utils/validation.lua
@@ -229,7 +229,7 @@ function M.validate_config_file(path)
             }
         else
             -- Creation succeeded. Write the default config.
-            local default_config = { mcpServers = {} }
+            local default_config = { mcpServers = vim.empty_dict() }
             local json_string = vim.json.encode(default_config) -- Convert to JSON string
 
             create_file:write(json_string) -- Write the JSON string to the file


### PR DESCRIPTION
## Description

This pull request addresses two issues related to the handling and creation of the MCPHub configuration file (`mcphub.json`) within the `validate_config_file` function:

1.  **Automatic Directory Creation:** Previously, if the specified configuration file path included directories that didn't exist, attempting to create the default configuration file would fail. This change ensures that all necessary parent directories are created automatically before writing the default file, improving the setup experience for users who prefer custom configuration locations.
2.  **Correct Default JSON Structure:** The default configuration was incorrectly generating `{"mcpServers":[]}` (an empty array) instead of the expected `{"mcpServers":{}}` (an empty object). This has been fixed by using `vim.empty_dict()` to ensure the generated JSON is valid and conforms to the required schema, preventing potential parsing errors or unexpected behavior later on.

These fixes enhance the robustness and reliability of the configuration file handling, particularly during the initial setup or when the configuration file is missing.

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
