### PR TITLE
Turn use_mcp_tool strict field to be false

### DIFF
--- a/lua/mcphub/extensions/codecompanion/init.lua
+++ b/lua/mcphub/extensions/codecompanion/init.lua
@@ -60,7 +60,7 @@ local tool_schemas = {
                 },
                 additionalProperties = false,
             },
-            strict = true,
+            strict = false,
         },
     },
 }


### PR DESCRIPTION
## Description
This PR resolves a schema validation error related to the use_mcp_tool function definition used in the OpenAI API.

When strict: true is set, the schema requires the tool_input object to explicitly define all properties and set additionalProperties: false. However, our current design uses implicit input structures for tool_input, meaning the keys are not predefined. This leads to the following error:
```
[ERROR] 2025-05-11 01:58:22                                                                                                                                                 
Error: {                                                                                                                                                                    
  "error": {                                                                                                                                                                
    "message": "Invalid schema for function 'use_mcp_tool': In context=('properties', 'tool_input'), 'additionalProperties' is required to be supplied and to be false.",   
    "type": "invalid_request_error",                                                                                                                                        
    "param": "tools[0].function.parameters",                                                                                                                                
    "code": "invalid_function_parameters"                                                                                                                                   
  }                                                                                                                                                                         
} 
```
We disable strict validation by setting `strict: false`. This allows the function to accept flexible key-value structures in `tool_input`, which aligns with our current usage pattern where each tool call defines its own shape implicitly.

## Related Issue(s)

## Screenshots

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
