### PR TITLE
fix: add plenary as a dependency in nix flake

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -6,24 +6,9 @@ on:
       - main
   pull_request: ~
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
-  cancel-in-progress: true
-
 jobs:
   tests:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
-          - os: ubuntu-latest
-            url: https://github.com/neovim/neovim/releases/download/v0.11.0/nvim-linux-x86_64.tar.gz
-          - os: ubuntu-latest
-            url: https://github.com/neovim/neovim/releases/download/v0.10.0/nvim-linux64.tar.gz
-
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v4

--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -1,0 +1,42 @@
+name: Nix Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request: ~
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  tests:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux-x86_64.tar.gz
+          - os: ubuntu-latest
+            url: https://github.com/neovim/neovim/releases/download/v0.11.0/nvim-linux-x86_64.tar.gz
+          - os: ubuntu-latest
+            url: https://github.com/neovim/neovim/releases/download/v0.10.0/nvim-linux64.tar.gz
+
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@v17
+
+      - name: Check Nixpkgs Inputs
+        uses: DeterminateSystems/flake-checker-action@v9
+
+      - name: Add Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@v9
+
+      - name: Run build ❄️
+        run: |
+          nix build

--- a/flake.nix
+++ b/flake.nix
@@ -18,25 +18,13 @@
         packages.default = pkgs.vimUtils.buildVimPlugin {
           name = "mcphub.nvim";
           src = self;
+          dependencies = [ pkgs.vimPlugins.plenary-nvim ];
           nvimSkipModule = [
-            "mcphub"
-            "mcphub.hub"
             "bundled_build"
             "mcphub.extensions.avante"
             "mcphub.extensions.codecompanion"
             "mcphub.extensions.codecompanion.xml_tool"
             "mcphub.extensions.lualine"
-            "mcphub.native.neovim.lsp"
-            "mcphub.native.neovim.terminal"
-            "mcphub.native.neovim.files.search"
-            "mcphub.native.neovim.files.write"
-            "mcphub.native.neovim.files.operations"
-            "mcphub.native.neovim.files.init"
-            "mcphub.native.neovim.files.replace"
-            "mcphub.native.neovim.init"
-            "mcphub.native.neovim.prompts"
-            "mcphub.native.mcphub.init"
-            "mcphub.native.mcphub.guide"
           ];
         };
       };


### PR DESCRIPTION
## Description

I added plenary as a dependency for the nix package. I also added a workflow to make sure that the nix package always works. This change was necessary because some modules didn't pass the check.

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
