### PR TITLE
Fix bug when server has only resource templates

### DIFF
--- a/lua/mcphub/utils/prompt.lua
+++ b/lua/mcphub/utils/prompt.lua
@@ -112,26 +112,25 @@ end
 ---@param templates MCPResourceTemplate[]
 ---@return string
 local function format_resources(resources, templates)
-    if not resources or #resources == 0 then
-        return ""
+    local result = ""
+    if resources and #resources > 0 then
+        result = result .. "\n\n### Available Resources"
+        for _, resource in ipairs(resources) do
+            result = result
+                .. string.format("\n\n- %s%s", resource.uri, resource.mimeType and " (" .. resource.mimeType .. ")" or "")
+            local desc = M.get_description(resource)
+            result = result .. "\n  " .. (resource.name or "") .. (desc == "" and "" or "\n  " .. desc)
+            -- result = result .. "\n\n" .. vim.inspect(remove_functions(resource))
+        end
     end
-    local result = "\n\n### Available Resources"
-    for _, resource in ipairs(resources) do
-        result = result
-            .. string.format("\n\n- %s%s", resource.uri, resource.mimeType and " (" .. resource.mimeType .. ")" or "")
-        local desc = M.get_description(resource)
-        result = result .. "\n  " .. (resource.name or "") .. (desc == "" and "" or "\n  " .. desc)
-        -- result = result .. "\n\n" .. vim.inspect(remove_functions(resource))
-    end
-    if not templates or #templates == 0 then
-        return result
-    end
-    result = result .. "\n\n### Available Resource Templates"
-    for _, template in ipairs(templates) do
-        result = result .. string.format("\n\n- %s", template.uriTemplate)
-        local desc = M.get_description(template)
-        result = result .. "\n  " .. (template.name or "") .. (desc == "" and "" or "\n  " .. desc)
-        -- result = result .. "\n\n" .. vim.inspect(remove_functions(template))
+    if templates and #templates > 0 then
+        result = result .. "\n\n### Available Resource Templates"
+        for _, template in ipairs(templates) do
+            result = result .. string.format("\n\n- %s", template.uriTemplate)
+            local desc = M.get_description(template)
+            result = result .. "\n  " .. (template.name or "") .. (desc == "" and "" or "\n  " .. desc)
+            -- result = result .. "\n\n" .. vim.inspect(remove_functions(template))
+        end
     end
     return result
 end


### PR DESCRIPTION
## Description

When an MCP server had only resource templates (and not any non-templated resources), the LLM wasn't being informed of the existence of the templated resources.

## Related Issue(s)

N/A

## Screenshots

N/A

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [N/A] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [N/A] I've run `make docs` to update the vimdoc pages
