### PR TITLE
fix: error concatening nil in checkhealth

### DIFF
--- a/lua/mcphub/health.lua
+++ b/lua/mcphub/health.lua
@@ -73,7 +73,7 @@ function M.check()
     local merged_config = State.config
     local cmd = merged_config.cmd
     local cmdArgs = merged_config.cmdArgs
-    local mcp_hub_path = cmd .. " " .. table.concat(cmdArgs, " ")
+    local mcp_hub_path = cmd .. " " .. table.concat(cmdArgs or {}, " ")
     local required_version = version.REQUIRED_NODE_VERSION.string
     info("  mcp-hub required version: " .. required_version)
     local installed_version = vim.fn.system(mcp_hub_path .. " --version")


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->
Running `:checkhealth` shows
```
mcphub.nvim ~
- mcphub.nvim version: 5.6.1
- mcp-hub binary:
- ❌ ERROR Failed to run healthcheck for "mcphub" plugin. Exception:
  ....local/share/nvim/lazy/mcphub.nvim/lua/mcphub/health.lua:76: bad argument #1 to 'concat' (table expected, got nil)
```

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [x ] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [ x] I've run `make test` to ensure all tests pass
- [ x] I've run `make format` to format the code
- [ x] I've run `make docs` to update the vimdoc pages
