### PR TITLE
feat: mention what server config is wrong

### DIFF
--- a/lua/mcphub/utils/validation.lua
+++ b/lua/mcphub/utils/validation.lua
@@ -94,7 +94,7 @@ function M.validate_server_config(name, config)
     if type(config) ~= "table" then
         return {
             ok = false,
-            error = Error("VALIDATION", Error.Types.SETUP.INVALID_CONFIG, "Config must be a table"),
+            error = Error("VALIDATION", Error.Types.SETUP.INVALID_CONFIG, string.format("Server '%s' config must be a table", name)),
         }
     end
 


### PR DESCRIPTION
I currently see in `:MCPHub`

```
  Setup Failed:
   Config must be a table (19m 50s)
```

which isn't helpful ?

After this change

```
  Setup Failed:  
   Server 'SQLite' config must be a table (5s)  
```    


## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

## Related Issue(s)
Note that it happened after installing the SQLITe mcp via the marketplace, so the installer itself generated a wrong config, which mcphub could have detected by itself (but that's another issue).

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ ] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [ ] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
