### PR TITLE
fix(codecompanion): help for @mcp in chat window

### DIFF
--- a/lua/mcphub/extensions/codecompanion/init.lua
+++ b/lua/mcphub/extensions/codecompanion/init.lua
@@ -75,7 +75,7 @@ function M.create_tools(opts)
     local tools = {
         groups = {
             mcp = {
-                description = " Call tools and resources from MCP servers with:\n\n - `use_mcp_tool`\n - `access_mcp_resource`\n",
+                description = "Call tools and resources from MCP servers",
                 system_prompt = function(_)
                     local hub = require("mcphub").get_hub_instance()
                     if not hub then


### PR DESCRIPTION
## Description

Change in commit 18710672477a3d9bb83ff1300bb934ef10127161 a couple of days ago breaks CodeCompanion help window (shown by `?` in chat window) - looks like group description must not be multi-line.

Right now pressing `?` result in this error:
```
E5108: Error executing lua: ...m/lazy/codecompanion.nvim/lua/codecompanion/utils/ui.lua:33: 'replace
ment string' item contains newlines                                                                 
stack traceback:                                                                                    
        [C]: in function 'nvim_buf_set_lines'                                                       
        ...m/lazy/codecompanion.nvim/lua/codecompanion/utils/ui.lua:33: in function 'create_float'  
        ...anion.nvim/lua/codecompanion/strategies/chat/keymaps.lua:134: in function 'rhs'          
        ...y/codecompanion.nvim/lua/codecompanion/utils/keymaps.lua:81: in function <...y/codecompan
ion.nvim/lua/codecompanion/utils/keymaps.lua:78>       
```

I've skipped `make docs` because it produce a lot of unrelated changes.

## Related Issue(s)

https://github.com/ravitemer/codecompanion-history.nvim/discussions/33#discussioncomment-13564418

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
