### PR TITLE
feat(codecompanion): add format_action

### DIFF
--- a/doc/extensions/codecompanion.md
+++ b/doc/extensions/codecompanion.md
@@ -27,6 +27,25 @@ require("codecompanion").setup({
         show_result_in_chat = true,  -- Show mcp tool results in chat
         make_vars = true,            -- Convert resources to #variables
         make_slash_commands = true,  -- Add prompts as /slash commands
+        format_action = function(action_name, tool)
+            -- Replace 'use_mcp_tool' with actual tool name and params.
+            if action_name == 'use_mcp_tool' then
+                local name = string.format(
+                    '%s/%s',
+                    tool.args.server_name,
+                    tool.args.tool_name
+                )
+                local tool_input = vim.deepcopy(tool.args.tool_input)
+                -- Cut too large params.
+                if name == 'filesystem/edit_file' then
+                  tool_input.edits = '󰩫'
+                elseif name == 'filesystem/write_file' then
+                  tool_input.content = '󰩫'
+                end
+                local args = vim.inspect(tool_input):gsub('%s+', ' ')
+                return name .. ' ' .. args
+            end
+        end,
       }
     }
   }

--- a/lua/mcphub/extensions/init.lua
+++ b/lua/mcphub/extensions/init.lua
@@ -12,6 +12,7 @@ local M = {}
 ---@field make_vars boolean Whether to make variables or not
 ---@field make_slash_commands boolean Whether to make slash commands or not
 ---@field show_result_in_chat boolean Whether to show the result in chat or not
+---@field format_action fun(action_name: MCPHub.ActionType, tool: CodeCompanion.Agent.Tool): string|nil
 
 ---@class MCPHub.Extensions.Config
 ---@field avante MCPHub.Extensions.AvanteConfig Configuration for the Avante extension


### PR DESCRIPTION
## Description

When tools is executed CodeCompanion does not show anything useful - all it says is "use_mcp_tool" has failed or succeeded. As "use_mcp_tool" is a meta-command, user do not see neither which tool was called, nor it args.

For successful execution it might be not critical and mostly just a curiosity to follow what LLM does.
But for failed runs it became a real UX issues, because in most cases failure happens because LLM uses wrong args, and now user needs to open a CodeCompanion debug output and try hard to find args used by LLM to spot an error and provide LLM with a hint how to fix it.

This PR adds support for a hook to let user format tool name and args to make them looks nice and useful.

## Screenshots

Before this PR:
![изображение](https://github.com/user-attachments/assets/3e9c997c-56db-4a67-888f-12ffb1c18f44)

After this PR, using example configuration:
![изображение](https://github.com/user-attachments/assets/c4ccef0c-e58c-4c13-adcd-7e0b6f120648)

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages

I've skipped `make docs` because it makes irrelevant changes - but it works ok for relevant changes.