### PR TITLE
chore: use json for input schema in @mcp prompt

### DIFF
--- a/lua/mcphub/utils/prompt.lua
+++ b/lua/mcphub/utils/prompt.lua
@@ -7,6 +7,7 @@ local M = {}
 local State = require("mcphub.state")
 local log = require("mcphub.utils.log")
 local native = require("mcphub.native")
+local utils = require("mcphub.utils")
 local validation = require("mcphub.utils.validation")
 
 ---@return string
@@ -90,8 +91,8 @@ local function format_tools(tools)
         result = result .. string.format("\n\n- %s: %s", tool.name, M.get_description(tool):gsub("\n", "\n  "))
         local inputSchema = M.get_inputSchema(tool)
         result = result
-            .. "\n\n  Input Schema:\n\n  ```lua\n  "
-            .. vim.inspect(inputSchema):gsub("\n", "\n  ")
+            .. "\n\n  Input Schema:\n\n  ```json\n  "
+            .. utils.pretty_json(vim.json.encode(inputSchema)):gsub("\n", "\n  ")
             .. "\n  ```"
     end
     return result


### PR DESCRIPTION
## Description

Use JSON for Input Schema in `@mcp` prompt instead of Lua.

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
