### PR TITLE
fix(copilotchat): add missing group for resource templates

### DIFF
--- a/lua/mcphub/extensions/copilotchat/functions.lua
+++ b/lua/mcphub/extensions/copilotchat/functions.lua
@@ -264,6 +264,7 @@ function M.register(opts)
                     chat.config.functions[function_name] = {
                         _mcphub = true,
                         uri = template.uriTemplate,
+                        group = safe_server_name,
                         description = template.description or "No description provided",
                         resolve = function(input)
                             local url = chat_functions.uri_to_url(template.uriTemplate, input or {})


### PR DESCRIPTION
Forgot to pass it in previous PR