### PR TITLE
typo: duplicate index 'global_env'

### DIFF
--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -90,10 +90,6 @@ All options are optional with sensible defaults. See below for each option in de
                 file_path = nil,
                 prefix = "MCPHub",
             },
-
-            -- Global environment variables available to all MCP servers
-            -- Can be a table or a function(context) -> table
-            global_env = {},
         })
     end
 }


### PR DESCRIPTION
## Description

<!-- Describe the big picture of your changes to communicate to the maintainers why we should accept this pull request. -->

hello i'm new here, I found one typo. Maybe it's not wrong, please feel free

## Related Issue(s)

<!--
  If this PR fixes any issues, please link to the issue here.
  - Fixes #<issue_number>
-->

## Screenshots

<!-- Add screenshots of the changes if applicable, to help visualize the change. -->

## Checklist

- [ x ] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ x ] I've updated the README and/or relevant docs pages
- [ x ] I've run `make test` to ensure all tests pass
- [ x ] I've run `make format` to format the code
- [ x ] I've run `make docs` to update the vimdoc pages
