### PR TITLE
fix(copilotchat): limit function names to 64 characters

### DIFF
--- a/lua/mcphub/extensions/copilotchat/functions.lua
+++ b/lua/mcphub/extensions/copilotchat/functions.lua
@@ -36,6 +36,11 @@ local function create_function_name(server_name, item_name, opts)
         name = "mcp_" .. name
     end
 
+    -- Limit the name to 64 characters
+    if #name > 64 then
+      name = name:sub(1, 64)
+    end
+
     return name
 end
 


### PR DESCRIPTION
Add a safeguard in `create_function_name` to ensure generated function names do not exceed 64 characters. This prevents potential issues with overly long function names when registering MCP tools and resources as CopilotChat functions.

Fixes this error when function name is too long.

```
{"error":{"message":"Invalid 'tools[0].function.name': string too long. Expected a string with maximum length 64, but got a string with length 81 instead.","code":"string_above_max_length"}}
```
