### PR TITLE
fix(utils): add prompts for renderer filter condition

### DIFF
--- a/lua/mcphub/utils/renderer.lua
+++ b/lua/mcphub/utils/renderer.lua
@@ -339,7 +339,10 @@ function M.render_server_capabilities(server, lines, current_line, server_config
         -- end
 
         if
-            #server.capabilities.tools + #server.capabilities.resources + #server.capabilities.resourceTemplates
+            #server.capabilities.tools
+                + #server.capabilities.resources
+                + #server.capabilities.resourceTemplates
+                + #server.capabilities.prompts
             == 0
         then
             table.insert(


### PR DESCRIPTION
## Description

When a native server only defines prompts without tools, resources or resource templates, the server will not show
any capabilities in the mcphub UI:

<img width="531" height="65" alt="image" src="https://github.com/user-attachments/assets/d8f27d4c-0111-4d13-b9b2-427472e9756e" />

with this little change, the prompts are also considered when deciding if capabilities are available:

<img width="531" height="99" alt="image" src="https://github.com/user-attachments/assets/f050619e-cc21-42df-8136-1af15e3be62b" />




## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages
