### PR TITLE
fix: Include a default border if winborder is not set.

### DIFF
--- a/lua/mcphub/utils/ui.lua
+++ b/lua/mcphub/utils/ui.lua
@@ -356,6 +356,7 @@ function M.confirm(message, opts)
 
         -- Enhanced window options with better styling
         win_opts.style = "minimal"
+        win_opts.border = vim.o.winborder ~= "" and vim.o.winborder or { "╭", "─", "╮", "│", "╯", "─", "╰", "│" }
         win_opts.title_pos = "center"
         win_opts.title = {
             { " MCPHUB Confirmation ", Text.highlights.header_btn },


### PR DESCRIPTION
## Description

Without setting a default border, the Yes / No / Cancel buttons and the header are not visible in the confirmation window for tool calls.

## Related Issue(s)
Fixes: #248 

## Checklist

- [X] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've run `make test` to ensure all tests pass
