### PR TITLE
fix: custom border chars

### DIFF
--- a/lua/mcphub/utils/ui.lua
+++ b/lua/mcphub/utils/ui.lua
@@ -356,7 +356,7 @@ function M.confirm(message, opts)
 
         -- Enhanced window options with better styling
         win_opts.style = "minimal"
-        win_opts.border = vim.o.winborder ~= "" and vim.o.winborder or { "╭", "─", "╮", "│", "╯", "─", "╰", "│" }
+        win_opts.border = vim.o.winborder == "" and { "╭", "─", "╮", "│", "╯", "─", "╰", "│" } or nil
         win_opts.title_pos = "center"
         win_opts.title = {
             { " MCPHUB Confirmation ", Text.highlights.header_btn },


### PR DESCRIPTION
## Problem

https://github.com/ravitemer/mcphub.nvim/pull/250 broke custom border char support for `winborder` option

## Solution

Do not explicitly set the border to `vim.o.winborder`. Just let it be `nil` and make neovim figure it out

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [ ] I've run `make format` to format the code
- [ ] I've run `make docs` to update the vimdoc pages

NOTE, there were a lot of docs changes when running `make docs`, but I didn't want to include them here as those are not relevant for my changes here