### PR TITLE
Fix CodeCompanion Config

### DIFF
--- a/doc/mcphub.txt
+++ b/doc/mcphub.txt
@@ -1,4 +1,4 @@
-*mcphub.nvim.txt*        For NVIM v0.10.0        Last change: 2025 December 12
+*mcphub.nvim.txt*        For NVIM v0.10.0        Last change: 2025 December 14
 
 ==============================================================================
 Table of Contents                              *mcphub.nvim-table-of-contents*

--- a/lua/mcphub/extensions/codecompanion/init.lua
+++ b/lua/mcphub/extensions/codecompanion/init.lua
@@ -24,7 +24,8 @@ function M.setup(opts)
     local tools = require("mcphub.extensions.codecompanion.tools")
     ---Add @mcp group with `use_mcp_tool` and `access_mcp_resource` tools
     local static_tools = tools.create_static_tools(opts)
-    cc_config.interactions.chat.tools = vim.tbl_deep_extend("force", cc_config.interactions.chat.tools, static_tools)
+    cc_config.config.interactions.chat.tools =
+        vim.tbl_deep_extend("force", cc_config.config.interactions.chat.tools, static_tools)
 
     ---Make each MCP server into groups and each tool from MCP server into function tools with proper namespacing
     tools.setup_dynamic_tools(opts)


### PR DESCRIPTION
## Description

Codecompanion now no longer exports its configuration directly, instead it exports { config: __the config__ }

So this deals with that

## Related Issue(s)

None reported yet I think.

## Screenshots

...

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
