### PR TITLE
Delete buffers after the window has closed

### DIFF
--- a/lua/mcphub/utils/ui.lua
+++ b/lua/mcphub/utils/ui.lua
@@ -110,7 +110,13 @@ function M.multiline_input(title, content, on_save, opts)
             end
         end
         -- Close the window
-        vim.api.nvim_win_close(win, true)
+        if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+        end
+
+        if vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end
         -- -- Call save callback if content changed
         -- if content ~= new_content then
         on_save(new_content)
@@ -118,7 +124,13 @@ function M.multiline_input(title, content, on_save, opts)
     end
 
     local function close_window()
-        vim.api.nvim_win_close(win, true)
+        if vim.api.nvim_win_is_valid(win) then
+            vim.api.nvim_win_close(win, true)
+        end
+
+        if vim.api.nvim_buf_is_valid(bufnr) then
+            vim.api.nvim_buf_delete(bufnr, { force = true })
+        end
         if opts.on_cancel then
             opts.on_cancel()
         end
@@ -387,9 +399,9 @@ function M.confirm(message, opts)
             is_closed = true
 
             vim.schedule(function()
-                    if vim.api.nvim_win_is_valid(win) then
-                        vim.api.nvim_win_close(win, true)
-                    end
+                if vim.api.nvim_win_is_valid(win) then
+                    vim.api.nvim_win_close(win, true)
+                end
 
                 if vim.api.nvim_buf_is_valid(bufnr) then
                     vim.api.nvim_buf_delete(bufnr, { force = true })


### PR DESCRIPTION
## Description

After a long session of AI assisted activities, I noticed quite a few hidden buffers still open from MCPHub for all of the confirmation windows. Not a huge performance problem, but it makes it clutters the hidden buffers menus and makes it harder to find the actual hidden buffers I might be looking for. Since these buffers are not used again, it's a bit of a memory leak to not clean them up.

## Checklist

- [X] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [X] I've updated the README and/or relevant docs pages
- [X] I've run `make test` to ensure all tests pass
- [X] I've run `make format` to format the code
- [X] I've run `make docs` to update the vimdoc pages
