### PR TITLE
fix(codecompanion): add additionalProperties to tool_input of use_mcp

### DIFF
--- a/lua/mcphub/extensions/codecompanion/tools.lua
+++ b/lua/mcphub/extensions/codecompanion/tools.lua
@@ -113,6 +113,7 @@ local tool_schemas = {
                     tool_input = {
                         description = "Input object for the tool call",
                         type = "object",
+                        additionalProperties = false,
                     },
                 },
                 required = { "server_name", "tool_name", "tool_input" },


### PR DESCRIPTION
## Description
Following error cause using GPT-5.x of github copilot on codecompanion.

```
[ERROR] 2026-01-15 19:50:48
Error: {"error":{"message":"Invalid schema for function 'use_mcp_tool': In context=('properties', 'tool_input', 'type', '0'), 'additionalProperties' is required to be supplied and to be false.","code":"invalid_request_body"}}
[ERROR] 2026-01-15 19:50:48
[chat::_submit_http] Error: {
  body = "{\"error\":{\"message\":\"Invalid schema for function 'use_mcp_tool': In context=('properties', 'tool_input', 'type', '0'), 'additionalProperties' is required to be supplied and to be false.\",\"code\":\"invalid_request_body\"}}",
  exit = 0,
  headers = { "content-security-policy: default-src 'none'; sandbox", "content-type: text/plain; charset=utf-8", "strict-transport-security: max-age=31536000", "x-content-type-options: nosniff", "x-request-id: 00000-e149250b-593b-4265-a5d7-c0adc069495a", "date: Thu, 15 Jan 2026 10:50:48 GMT", "content-length: 219", "x-github-backend: Kubernetes", "x-github-request-id: F3C9:2D4625:2114F0:256D7F:6968C687" },
  status = 400
}
```

The error occurs because tool_input is an object. https://github.com/olimorris/codecompanion.nvim/pull/2334 supports strict mode for nested objects, and it works correctly by simply adding `additionalProperties`.

## Related Issue(s)

- Fix https://github.com/olimorris/codecompanion.nvim/issues/2314#issuecomment-3592570459

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
