### PR TITLE
Implement after the fact review system

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ MCP Hub is a MCP client for neovim that seamlessly integrates [MCP (Model Contex
 | | Headers | ✅ | For API keys/tokens |
 | **Chat Integration** ||||
 | | [Avante.nvim](https://github.com/yetone/avante.nvim) | ✅ | Tools, resources, resourceTemplates, prompts(as slash_commands) |
-| | [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim) | ✅ | Tools, resources, templates, prompts (as slash_commands), 🖼 image responses | 
+| | [CodeCompanion.nvim](https://github.com/olimorris/codecompanion.nvim) | ✅ | Tools, resources, templates, prompts (as slash_commands), 🖼 image responses, 🔒 tool result review | 
 | | [CopilotChat.nvim](https://github.com/CopilotC-Nvim/CopilotChat.nvim) | ✅ | Tools, resources, function calling support |
+| **Security & Control** ||||
+| | Tool Confirmation | ✅ | User confirmation before tool execution |
+| | Result Review | ✅ | Inspect & approve/reject tool results before sending to LLM |
+| | Granular Auto-Approval | ✅ | Per-server, per-tool, or function-based approval rules |
 | **Marketplace** ||||
 | | Server Discovery | ✅ | Browse from verified MCP servers |
 | | Installation | ✅ | Manual and auto install with AI |

--- a/doc/extensions/codecompanion.md
+++ b/doc/extensions/codecompanion.md
@@ -156,12 +156,30 @@ If `make_slash_commands = true`, MCP prompts are available as slash commands:
 
 
 
-## Auto-Approval
+## Tool Approval & Review
 
 By default, whenever codecompanion calls `use_mcp_tool` or `access_mcp_resource` tool or a specific tool on some MCP server, it shows a confirm dialog with tool name, server name and arguments.
 
 ![Image](https://github.com/user-attachments/assets/201a5804-99b6-4284-9351-348899e62467)
 
+### Review Tool Results
+
+The confirmation dialog now includes a **"Yes & Review"** option, allowing you to inspect tool results before they're sent to the LLM. This is particularly useful for preventing sensitive data leakage when working with tools that access confidential information (JIRA, Confluence, databases, etc.).
+
+**Keyboard shortcuts in confirmation dialog:**
+- `y`/`Y` - Yes (execute and auto-send to LLM)
+- `r`/`R` - **Yes & Review** (execute, then show review window)
+- `n`/`N` - No (don't execute)
+- `c`/`C` or `<Esc>` - Cancel
+
+When you select "Yes & Review", the tool executes and then displays a review window where you can:
+- Inspect the full result (with scrolling for large outputs)
+- Approve to send to LLM (`y`, `a`, or `<CR>` on Approve)
+- Reject to prevent data leakage (`n`, `r`, or `<Esc>`)
+
+**See the full documentation**: [Tool Result Review Feature](/other/review-feature)
+
+### Auto-Approval
 
 #### Fine-Grained Auto-Approval
 
@@ -239,6 +257,11 @@ require("mcphub").setup({
             end
         end
 
+        -- Execute JIRA/Confluence tools but always review results
+        if params.server_name == "jira" or params.server_name == "confluence" then
+            return { approve = true, review = true }
+        end
+
         -- Check if tool is configured for auto-approval in servers.json
         if params.is_auto_approved_in_server then
             return true -- Respect servers.json configuration
@@ -258,8 +281,9 @@ require("mcphub").setup({
 - `params.is_auto_approved_in_server` - Boolean indicating if tool is configured for auto-approval in servers.json
 
 **Return values:**
-- `true` - Auto-approve the call
-- `false` - Show confirmation prompt
+- `true` - Auto-approve and execute immediately (no review)
+- `false` - Show confirmation prompt (user can choose review)
+- `{ approve = true, review = true }` - Execute and force review window
 - `string` - Deny with error message
 - `nil` - Show confirmation prompt (same as false)
 

--- a/doc/mcphub.txt
+++ b/doc/mcphub.txt
@@ -1,4 +1,4 @@
-*mcphub.nvim.txt*        For NVIM v0.10.0        Last change: 2025 December 12
+*mcphub.nvim.txt*        For NVIM v0.10.0        Last change: 2026 February 17
 
 ==============================================================================
 Table of Contents                              *mcphub.nvim-table-of-contents*
@@ -3295,11 +3295,34 @@ If `make_slash_commands = true`, MCP prompts are available as slash commands:
 _Example: Using an MCP prompt via slash command_:
 
 
-AUTO-APPROVAL ~
+TOOL APPROVAL & REVIEW ~
 
 By default, whenever codecompanion calls `use_mcp_tool` or
 `access_mcp_resource` tool or a specific tool on some MCP server, it shows a
 confirm dialog with tool name, server name and arguments.
+
+
+REVIEW TOOL RESULTS
+
+The confirmation dialog now includes a **“Yes & Review”** option, allowing
+you to inspect tool results before they’re sent to the LLM. This is
+particularly useful for preventing sensitive data leakage when working with
+tools that access confidential information (JIRA, Confluence, databases, etc.).
+
+**Keyboard shortcuts in confirmation dialog:** - `y`/`Y` - Yes (execute and
+auto-send to LLM) - `r`/`R` - **Yes & Review** (execute, then show review
+window) - `n`/`N` - No (don’t execute) - `c`/`C` or `<Esc>` - Cancel
+
+When you select "Yes & Review", the tool executes and then displays a review
+window where you can: - Inspect the full result (with scrolling for large
+outputs) - Approve to send to LLM (`y`, `a`, or `<CR>` on Approve) - Reject to
+prevent data leakage (`n`, `r`, or `<Esc>`)
+
+**See the full documentation**: Tool Result Review Feature
+</other/review-feature>
+
+
+AUTO-APPROVAL
 
 
 FINE-GRAINED AUTO-APPROVAL
@@ -3378,6 +3401,11 @@ specific tool call:
                 end
             end
     
+            -- Execute JIRA/Confluence tools but always review results
+            if params.server_name == "jira" or params.server_name == "confluence" then
+                return { approve = true, review = true }
+            end
+    
             -- Check if tool is configured for auto-approval in servers.json
             if params.is_auto_approved_in_server then
                 return true -- Respect servers.json configuration
@@ -3395,9 +3423,10 @@ resources) - `params.arguments` - Table of arguments passed to the tool -
 - Resource URI (for resource access) - `params.is_auto_approved_in_server` -
 Boolean indicating if tool is configured for auto-approval in servers.json
 
-**Return values:** - `true` - Auto-approve the call - `false` - Show
-confirmation prompt - `string` - Deny with error message - `nil` - Show
-confirmation prompt (same as false)
+**Return values:** - `true` - Auto-approve and execute immediately (no review)
+- `false` - Show confirmation prompt (user can choose review) - `{ approve =
+true, review = true }` - Execute and force review window - `string` - Deny with
+error message - `nil` - Show confirmation prompt (same as false)
 
 
 AUTO-APPROVAL PRIORITY

--- a/doc/other/review-feature.md
+++ b/doc/other/review-feature.md
@@ -1,0 +1,287 @@
+# Tool Result Review Feature
+
+The "Yes & Review" feature provides an additional layer of control over MCP tool execution, allowing you to review tool results before they're sent to the LLM. This is particularly useful when working with tools that might return sensitive information.
+
+## Overview
+
+When executing MCP tools, you now have four options in the confirmation dialog:
+
+1. **Yes** - Execute the tool and send results directly to the LLM
+2. **Yes & Review** - Execute the tool, then show a review window before sending to LLM
+3. **No** - Don't execute the tool
+4. **Cancel** - Cancel the operation
+
+## Use Cases
+
+### Prevent Data Leakage
+
+When using MCP servers that access sensitive data (e.g., JIRA, Confluence, internal databases), you may want to review the results before they're shared with the LLM:
+
+```
+LLM: "Let me check your recent JIRA issues"
+You: Press 'r' for "Yes & Review"
+Tool executes and fetches JIRA data
+Review window appears with the results
+You can inspect for sensitive information
+Approve or reject before sending to LLM
+```
+
+### Quality Control
+
+Review tool outputs to ensure they're correct and relevant before the LLM processes them, especially for:
+- Complex queries with large result sets
+- File operations that might have grabbed wrong content
+- API calls that might have returned unexpected data
+
+### Learning and Debugging
+
+See exactly what data tools are returning to help:
+- Understand how MCP servers work
+- Debug issues with tool calls
+- Learn what information is being shared with the LLM
+
+## How It Works
+
+### Confirmation Flow
+
+When a tool requires confirmation, you'll see:
+
+```
+┌─────────────────────────────────────────┐
+│       MCPHUB Confirmation               │
+├─────────────────────────────────────────┤
+│ Server: github                          │
+│ Tool: search_issues                     │
+│ Arguments: { repo: "user/project" }     │
+│                                         │
+│  [Yes]  [Yes & Review]  [No]  [Cancel]  │
+└─────────────────────────────────────────┘
+```
+
+**Keyboard shortcuts:**
+- `y`/`Y` - Yes (execute and auto-send)
+- `r`/`R` - Yes & Review (execute and show review window)
+- `n`/`N` - No (don't execute)
+- `c`/`C` or `<Esc>` or `q` - Cancel
+- `<Tab>` - Navigate between options
+- `<CR>` - Execute highlighted option
+
+### Review Window
+
+If you select "Yes & Review", after the tool executes, you'll see a review window:
+
+```
+┌────────────────────────────────────────────┐
+│         Tool Result Review                 │
+├────────────────────────────────────────────┤
+│ Server: jira                               │
+│ Tool: search_issues                        │
+│                                            │
+│ ━━━ Result ━━━                             │
+│                                            │
+│ [Scrollable content showing tool results] │
+│ • Text results are displayed              │
+│ • Images show count indicator             │
+│ • Errors are highlighted                  │
+│                                            │
+│        [Approve]    [Reject]               │
+└────────────────────────────────────────────┘
+```
+
+**Keyboard shortcuts:**
+- `y`/`Y` or `a`/`A` - Approve (send result to LLM)
+- `n`/`N` or `r`/`R` - Reject (don't send to LLM)
+- `<Esc>` or `q` - Reject (same as above)
+- `<Tab>` - Navigate between Approve/Reject
+- `<CR>` - Execute highlighted option
+
+**Scrolling:**
+- `j`/`k` - Scroll line by line
+- `<C-d>`/`<C-u>` - Scroll half page
+- `gg`/`G` - Jump to top/bottom
+
+### What Happens on Rejection
+
+When you reject a tool result, the LLM receives a neutral message instead:
+
+```
+"Tool result was rejected by the user during review."
+```
+
+This allows the LLM to:
+- Ask you what information you need instead
+- Try a different approach
+- Request clarification on what to do next
+
+The actual tool result is never sent to the LLM, preventing any sensitive data leakage.
+
+## Configuration
+
+### Using auto_approve Function
+
+You can use the `auto_approve` function to automatically trigger review for specific servers or tools:
+
+```lua
+require("mcphub").setup({
+    auto_approve = function(params)
+        -- Auto-approve filesystem operations (no review needed)
+        if params.server_name == "neovim" then
+            return true
+        end
+        
+        -- Execute JIRA/Confluence tools but always review results
+        if params.server_name == "jira" or params.server_name == "confluence" then
+            return { approve = true, review = true }
+        end
+        
+        -- Execute but review for any tool accessing external APIs
+        if params.tool_name and params.tool_name:match("^fetch") then
+            return { approve = true, review = true }
+        end
+        
+        -- Everything else requires manual confirmation
+        return false
+    end
+})
+```
+
+**Return values:**
+- `true` - Execute immediately, no review
+- `false` - Show confirmation dialog (user can choose review)
+- `{ approve: true, review: true }` - Execute and force review
+- `{ approve: false, review: false }` - Don't execute (same as false)
+- `string` - Deny with error message
+
+### Important Notes
+
+1. **Auto-approved tools skip review**: If a tool is auto-approved (via `auto_approve = true`, `servers.json` `autoApprove`, or function returning `true`), it will execute and send results directly to the LLM without showing any dialogs.
+
+2. **Review is always available**: The "Yes & Review" option appears in all confirmation dialogs. Users can always choose to review results even if not configured.
+
+3. **Review happens after execution**: The tool runs first, then results are shown for review. This means side effects (like creating a file) have already occurred, but you control what data reaches the LLM.
+
+## Examples
+
+### Example 1: Reviewing JIRA Data
+
+```lua
+-- Configuration
+require("mcphub").setup({
+    auto_approve = function(params)
+        if params.server_name == "jira" then
+            return { approve = true, review = true }
+        end
+        return false
+    end
+})
+```
+
+When CodeCompanion calls a JIRA tool:
+1. Tool executes automatically (no confirmation dialog)
+2. Review window appears with JIRA data
+3. You inspect the issues, descriptions, etc.
+4. Approve if data is safe, reject if it contains sensitive info
+5. LLM only sees approved data
+
+### Example 2: Manual Review for Database Queries
+
+```lua
+-- Configuration
+require("mcphub").setup({
+    auto_approve = function(params)
+        -- Always require confirmation for database operations
+        if params.server_name == "postgres" or params.server_name == "mongodb" then
+            return false -- Show confirmation dialog
+        end
+        return false
+    end
+})
+```
+
+When CodeCompanion wants to query a database:
+1. Confirmation dialog appears
+2. You press `r` for "Yes & Review"
+3. Query executes
+4. Review window shows the query results
+5. You can verify no PII or sensitive data is present
+6. Approve to continue
+
+### Example 3: Selective Review Based on Arguments
+
+```lua
+require("mcphub").setup({
+    auto_approve = function(params)
+        -- Auto-approve reading from public directories
+        if params.tool_name == "read_file" then
+            local path = params.arguments.path or ""
+            if path:match("/public/") or path:match("/docs/") then
+                return true -- No review needed
+            end
+            -- Force review for other paths
+            return { approve = true, review = true }
+        end
+        
+        return false
+    end
+})
+```
+
+## Security Considerations
+
+### Why This Feature Exists
+
+MCP tools can access and return sensitive information:
+- Personal data from issue trackers
+- Confidential documents
+- API keys or credentials in config files
+- Internal company information
+- Private code or data
+
+Once this information reaches the LLM, you lose control over it. The review feature ensures you maintain control over what data is shared.
+
+### Best Practices
+
+1. **Review by default for sensitive sources**: Configure auto-review for any MCP server that accesses:
+   - Internal company tools (JIRA, Confluence, etc.)
+   - Databases with customer data
+   - Private repositories or codebases
+   - Any service with PII (Personally Identifiable Information)
+
+2. **Auto-approve safe operations**: It's safe to auto-approve (without review):
+   - Local file operations in public directories
+   - Read-only operations on public data
+   - Tools you've thoroughly vetted
+
+3. **Use rejection strategically**: When you reject results:
+   - The tool has already executed (side effects occurred)
+   - Only the data transmission to LLM is prevented
+   - Use this for data leakage prevention, not execution prevention
+
+4. **Combine with other security measures**:
+   - Use MCP server permissions and scopes
+   - Configure tools with least-privilege access
+   - Review `servers.json` configurations regularly
+
+## Troubleshooting
+
+### Review window closes immediately
+
+Make sure you're not in insert mode. The review window operates in normal mode with specific key bindings.
+
+### Results are truncated
+
+Very large results (>10,000 lines) are automatically truncated to prevent performance issues. The truncation message will indicate how many lines are shown vs. total.
+
+### Tool executes even when rejected
+
+This is expected behavior. The review happens *after* execution. If you need to prevent execution entirely, select "No" or "Cancel" in the confirmation dialog instead of "Yes & Review".
+
+### Can't see images in review window
+
+Images are shown as a count indicator (e.g., "📷 2 images included") in the review window. The actual images are still included in the result when approved, and CodeCompanion will display them in the chat buffer.
+
+## Related Documentation
+
+- [CodeCompanion Integration](/extensions/codecompanion) - Full CodeCompanion extension documentation
+- [Configuration](/configuration) - Main configuration options including `auto_approve`
+- [Architecture: Review Flow](/other/architecture/review-flow) - Technical implementation details

--- a/lua/mcphub/config.lua
+++ b/lua/mcphub/config.lua
@@ -57,7 +57,12 @@ local defaults = {
     --- Custom function to parse json file (e.g `require'json5'.parse` from `https://github.com/Joakker/lua-json5 to parse json5 syntax for .vscode/mcp.json like files)
     ---@type function | nil
     json_decode = nil,
-    ---@type boolean | fun(parsed_params: MCPHub.ParsedParams): boolean | nil | string  Function to determine if a call should be auto-approved
+    ---@type boolean | fun(parsed_params: MCPHub.ParsedParams): boolean | nil | string | {approve: boolean, review: boolean}
+    --- Function to determine if a call should be auto-approved. Can return:
+    --- - `boolean`: approve (true) or deny (false) the operation
+    --- - `string`: error message (treated as denial)
+    --- - `{approve: boolean, review: boolean}`: approve and optionally request review before sending to LLM
+    --- - `nil`: denial
     auto_approve = false,
     auto_toggle_mcp_servers = true, -- Let LLMs start and stop MCP servers automatically
     use_bundled_binary = false, -- Whether to use bundled mcp-hub binary

--- a/lua/mcphub/extensions/codecompanion/core.lua
+++ b/lua/mcphub/extensions/codecompanion/core.lua
@@ -38,6 +38,33 @@ function M.execute_mcp_tool(params, agent, output_handler, context)
             })
         end
 
+        -- Helper function to handle review flow
+        ---@param res MCPResponseOutput
+        ---@param metadata table
+        local function handle_review_flow(res, metadata)
+            if not result.review_requested then
+                -- No review requested, pass through directly
+                output_handler({ status = "success", data = res })
+                return
+            end
+
+            -- Show review window
+            local ui_utils = require("mcphub.utils.ui")
+            ui_utils.review_tool_result(res, metadata, function(approved)
+                if approved then
+                    -- User approved, send actual result
+                    output_handler({ status = "success", data = res })
+                else
+                    -- User rejected, send rejection message
+                    local rejected_result = {
+                        text = "Tool result was rejected by the user during review.",
+                        isError = false,
+                    }
+                    output_handler({ status = "success", data = rejected_result })
+                end
+            end)
+        end
+
         -- Call appropriate hub method
         if parsed_params.action == "access_mcp_resource" then
             hub:access_resource(parsed_params.server_name, parsed_params.uri, {
@@ -45,6 +72,12 @@ function M.execute_mcp_tool(params, agent, output_handler, context)
                     type = "codecompanion",
                     codecompanion = agent,
                     auto_approve = result.approve,
+                    review_requested = result.review_requested,
+                    review_metadata = {
+                        server_name = parsed_params.server_name,
+                        uri = parsed_params.uri,
+                        action = "access_mcp_resource",
+                    },
                 },
                 parse_response = true,
                 callback = function(res, err)
@@ -55,7 +88,11 @@ function M.execute_mcp_tool(params, agent, output_handler, context)
                                 or "No response from accessing the resource " .. parsed_params.uri,
                         })
                     elseif res then
-                        output_handler({ status = "success", data = res })
+                        handle_review_flow(res, {
+                            server_name = parsed_params.server_name,
+                            uri = parsed_params.uri,
+                            action = "access_mcp_resource",
+                        })
                     end
                 end,
             })
@@ -65,6 +102,12 @@ function M.execute_mcp_tool(params, agent, output_handler, context)
                     type = "codecompanion",
                     codecompanion = agent,
                     auto_approve = result.approve,
+                    review_requested = result.review_requested,
+                    review_metadata = {
+                        server_name = parsed_params.server_name,
+                        tool_name = parsed_params.tool_name,
+                        action = "use_mcp_tool",
+                    },
                 },
                 parse_response = true,
                 callback = function(res, err)
@@ -73,7 +116,11 @@ function M.execute_mcp_tool(params, agent, output_handler, context)
                     elseif res.error then
                         output_handler({ status = "error", data = res.error })
                     else
-                        output_handler({ status = "success", data = res })
+                        handle_review_flow(res, {
+                            server_name = parsed_params.server_name,
+                            tool_name = parsed_params.tool_name,
+                            action = "use_mcp_tool",
+                        })
                     end
                 end,
             })

--- a/lua/mcphub/extensions/shared.lua
+++ b/lua/mcphub/extensions/shared.lua
@@ -15,6 +15,7 @@ local utils = require("mcphub.utils")
 ---@field uri string URI of the resource to access (nil for tools)
 ---@field is_auto_approved_in_server boolean Whether the tool autoApproved in the servers.json
 ---@field needs_confirmation_window boolean Whether the tool call needs a confirmation window
+---@field review_requested boolean Whether user wants to review result before sending to LLM
 
 ---@class MCPHub.ToolCallArgs
 ---@field server_name string Name of the server to call the tool on.
@@ -91,6 +92,7 @@ function M.parse_params(params, action_name)
         uri = uri or "nil",
         needs_confirmation_window = M.needs_confirmation_window(server_name, tool_name),
         is_auto_approved_in_server = M.is_auto_approved_in_server(server_name, tool_name),
+        review_requested = false, -- Will be set by confirmation dialog
     }
 end
 
@@ -109,6 +111,7 @@ function M.needs_confirmation_window(server_name, tool_name)
     end
     return true
 end
+
 ---@param arguments MCPPromptArgument[]
 ---@param callback fun(values: string[])
 function M.collect_arguments(arguments, callback)
@@ -197,6 +200,7 @@ end
 ---@param params MCPHub.ParsedParams
 ---@return boolean confirmed
 ---@return boolean cancelled
+---@return boolean review_requested
 function M.show_mcp_tool_prompt(params)
     local action_name = params.action
     local server_name = params.server_name
@@ -274,7 +278,7 @@ function M.show_mcp_tool_prompt(params)
         uri = uri,
         arguments = arguments,
     })
-    local confirmed, cancelled = require("mcphub.utils.ui").confirm(lines, {
+    local confirmed, cancelled, review_requested = require("mcphub.utils.ui").confirm(lines, {
         min_width = 70,
         max_width = 100,
     })
@@ -287,44 +291,66 @@ function M.show_mcp_tool_prompt(params)
         arguments = arguments,
         confirmed = confirmed,
         cancelled = cancelled,
+        review_requested = review_requested,
     })
 
-    return confirmed, cancelled
+    return confirmed, cancelled, review_requested
 end
 
 ---@param parsed_params MCPHub.ParsedParams
----@return {error?:string, approve:boolean}
+---@return {error?:string, approve:boolean, review_requested:boolean}
 function M.handle_auto_approval_decision(parsed_params)
     local auto_approve = State.config.auto_approve or false
-    local status = { approve = false, error = nil }
+    local status = { approve = false, error = nil, review_requested = false }
+
     --- If user has a custom function that decides whether to auto-approve
     --- call that with params + saved autoApprove state as is_auto_approved_in_server field
     if type(auto_approve) == "function" then
         local ok, res = pcall(auto_approve, parsed_params)
         if not ok or type(res) == "string" then
             --- If auto_approve function throws an error, or returns a string, treat it as an error
-            status = { approve = false, error = res }
+            status = { approve = false, error = res, review_requested = false }
         elseif type(res) == "boolean" then
             --- If auto_approve function returns a boolean, use that as the decision
-            status = { approve = res, error = nil }
+            status = { approve = res, error = nil, review_requested = false }
+        elseif type(res) == "table" then
+            --- If auto_approve function returns a table, extract approve and review flags
+            status = {
+                approve = res.approve == true,
+                error = nil,
+                review_requested = res.review == true,
+            }
         end
     elseif type(auto_approve) == "boolean" then
-        status = { approve = auto_approve, error = nil }
+        status = { approve = auto_approve, error = nil, review_requested = false }
     end
 
     -- Check if auto-approval is enabled in servers.json
     if parsed_params.is_auto_approved_in_server then
-        status = { approve = true, error = nil }
+        status = { approve = true, error = nil, review_requested = false }
     end
 
     if status.error then
-        return { error = status.error or "Something went wrong with auto-approval", approve = false }
+        return {
+            error = status.error or "Something went wrong with auto-approval",
+            approve = false,
+            review_requested = false,
+        }
     end
 
     if status.approve == false and parsed_params.needs_confirmation_window then
-        local confirmed, _ = M.show_mcp_tool_prompt(parsed_params)
-        return { error = not confirmed and "User cancelled the operation", approve = confirmed }
+        local confirmed, cancelled, review_requested = M.show_mcp_tool_prompt(parsed_params)
+
+        -- Update parsed_params with review request
+        parsed_params.review_requested = review_requested
+
+        return {
+            error = not confirmed and "User cancelled the operation",
+            approve = confirmed,
+            review_requested = review_requested,
+        }
     end
+
     return status
 end
 

--- a/lua/mcphub/native/utils/server.lua
+++ b/lua/mcphub/native/utils/server.lua
@@ -284,6 +284,38 @@ function NativeServer:call_tool(name, arguments, opts)
         tool_result = result
         tool_error = err
         tool_finished = true
+
+        -- Handle review flow if requested
+        local caller = opts.caller or {}
+        if caller.review_requested and result and not err then
+            local ui_utils = require("mcphub.utils.ui")
+            local metadata = caller.review_metadata
+                or {
+                    server_name = self.name,
+                    tool_name = name,
+                    action = "use_mcp_tool",
+                }
+
+            ui_utils.review_tool_result(result, metadata, function(approved)
+                if approved then
+                    -- User approved, continue with actual result
+                    if opts.callback then
+                        opts.callback(result, err)
+                    end
+                else
+                    -- User rejected, send rejection message
+                    local rejected_result = {
+                        text = "Tool result was rejected by the user during review.",
+                        isError = false,
+                    }
+                    if opts.callback then
+                        opts.callback(rejected_result, nil)
+                    end
+                end
+            end)
+            return
+        end
+
         if opts.callback then
             opts.callback(result, err)
             return
@@ -362,6 +394,38 @@ function NativeServer:access_resource(uri, opts)
         resource_result = result
         resource_error = err
         resource_accessed = true
+
+        -- Handle review flow if requested
+        local caller = opts.caller or {}
+        if caller.review_requested and result and not err then
+            local ui_utils = require("mcphub.utils.ui")
+            local metadata = caller.review_metadata
+                or {
+                    server_name = self.name,
+                    uri = uri,
+                    action = "access_mcp_resource",
+                }
+
+            ui_utils.review_tool_result(result, metadata, function(approved)
+                if approved then
+                    -- User approved, continue with actual result
+                    if opts.callback then
+                        opts.callback(result, err)
+                    end
+                else
+                    -- User rejected, send rejection message
+                    local rejected_result = {
+                        text = "Tool result was rejected by the user during review.",
+                        isError = false,
+                    }
+                    if opts.callback then
+                        opts.callback(rejected_result, nil)
+                    end
+                end
+            end)
+            return
+        end
+
         if opts.callback then
             opts.callback(result, err)
             return

--- a/lua/mcphub/utils/ui.lua
+++ b/lua/mcphub/utils/ui.lua
@@ -110,13 +110,7 @@ function M.multiline_input(title, content, on_save, opts)
             end
         end
         -- Close the window
-        if vim.api.nvim_win_is_valid(win) then
-            vim.api.nvim_win_close(win, true)
-        end
-
-        if vim.api.nvim_buf_is_valid(bufnr) then
-            vim.api.nvim_buf_delete(bufnr, { force = true })
-        end
+        vim.api.nvim_win_close(win, true)
         -- -- Call save callback if content changed
         -- if content ~= new_content then
         on_save(new_content)
@@ -124,13 +118,7 @@ function M.multiline_input(title, content, on_save, opts)
     end
 
     local function close_window()
-        if vim.api.nvim_win_is_valid(win) then
-            vim.api.nvim_win_close(win, true)
-        end
-
-        if vim.api.nvim_buf_is_valid(bufnr) then
-            vim.api.nvim_buf_delete(bufnr, { force = true })
-        end
+        vim.api.nvim_win_close(win, true)
         if opts.on_cancel then
             opts.on_cancel()
         end
@@ -244,16 +232,16 @@ function M.get_selection(bufnr)
     }
 end
 
----Create a confirmation window with Yes/No/Cancel options
+---Create a confirmation window with Yes/Yes & Review/No/Cancel options
 ---@param message string | string[] | NuiLine[] Message to display
 ---@param opts? {relative_to_chat?: boolean, min_width?: number, max_width?: number}
----@return boolean, boolean -- (confirmed, cancelled)
+---@return boolean, boolean, boolean -- (confirmed, cancelled, review_requested)
 function M.confirm(message, opts)
     opts = opts or {}
 
     local result = async.wrap(function(callback)
         if not message or #message == 0 then
-            return callback(false, true)
+            return callback(false, true, false)
         end
 
         -- Track active option (default to "yes")
@@ -266,6 +254,11 @@ function M.confirm(message, opts)
                 {
                     " Yes ",
                     active_option == "yes" and Text.highlights.button_active or Text.highlights.button_inactive,
+                },
+                { " • ", Text.highlights.seamless_border },
+                {
+                    " Yes & Review ",
+                    active_option == "yes_review" and Text.highlights.button_active or Text.highlights.button_inactive,
                 },
                 { " • ", Text.highlights.seamless_border },
                 { " No ", active_option == "no" and Text.highlights.button_active or Text.highlights.button_inactive },
@@ -368,7 +361,8 @@ function M.confirm(message, opts)
 
         -- Enhanced window options with better styling
         win_opts.style = "minimal"
-        win_opts.border = vim.o.winborder == "" and { "╭", "─", "╮", "│", "╯", "─", "╰", "│" } or nil
+        win_opts.border = vim.o.winborder ~= "" and vim.o.winborder
+            or { "╭", "─", "╮", "│", "╯", "─", "╰", "│" }
         win_opts.title_pos = "center"
         win_opts.title = {
             { " MCPHUB Confirmation ", Text.highlights.header_btn },
@@ -391,7 +385,7 @@ function M.confirm(message, opts)
         local is_closed = false
 
         -- Enhanced close function with cleanup
-        local function close_window(confirmed, cancelled)
+        local function close_window(confirmed, cancelled, review_requested)
             if is_closed then
                 return
             end
@@ -399,24 +393,24 @@ function M.confirm(message, opts)
 
             vim.schedule(function()
                 if vim.api.nvim_win_is_valid(win) then
-                    vim.api.nvim_win_close(win, true)
+                    if vim.api.nvim_win_is_valid(win) then
+                        vim.api.nvim_win_close(win, true)
+                    end
                 end
-
-                if vim.api.nvim_buf_is_valid(bufnr) then
-                    vim.api.nvim_buf_delete(bufnr, { force = true })
-                end
-                callback(confirmed, cancelled)
+                callback(confirmed, cancelled, review_requested)
             end)
         end
 
         -- Function to execute active option
         local function execute_active_option()
             if active_option == "yes" then
-                close_window(true, false)
+                close_window(true, false, false)
+            elseif active_option == "yes_review" then
+                close_window(true, false, true)
             elseif active_option == "no" then
-                close_window(false, false)
+                close_window(false, false, false)
             else -- cancel
-                close_window(false, true)
+                close_window(false, true, false)
             end
         end
 
@@ -424,33 +418,41 @@ function M.confirm(message, opts)
         local keymaps = {
             -- Direct actions
             ["y"] = function()
-                close_window(true, false)
+                close_window(true, false, false)
             end,
             ["Y"] = function()
-                close_window(true, false)
+                close_window(true, false, false)
+            end,
+            ["r"] = function()
+                close_window(true, false, true)
+            end,
+            ["R"] = function()
+                close_window(true, false, true)
             end,
             ["n"] = function()
-                close_window(false, false)
+                close_window(false, false, false)
             end,
             ["N"] = function()
-                close_window(false, false)
+                close_window(false, false, false)
             end,
             ["c"] = function()
-                close_window(false, true)
+                close_window(false, true, false)
             end,
             ["C"] = function()
-                close_window(false, true)
+                close_window(false, true, false)
             end,
             ["<Esc>"] = function()
-                close_window(false, true)
+                close_window(false, true, false)
             end,
             ["q"] = function()
-                close_window(false, true)
+                close_window(false, true, false)
             end,
             ["<CR>"] = execute_active_option, -- Execute the currently active option
             -- Tab navigation
             ["<Tab>"] = function()
                 if active_option == "yes" then
+                    active_option = "yes_review"
+                elseif active_option == "yes_review" then
                     active_option = "no"
                 elseif active_option == "no" then
                     active_option = "cancel"
@@ -476,7 +478,7 @@ function M.confirm(message, opts)
             buffer = bufnr,
             group = group,
             callback = function()
-                close_window(false, true)
+                close_window(false, true, false)
             end,
             once = true,
         })
@@ -489,6 +491,288 @@ function M.confirm(message, opts)
     end, 1)
 
     return result()
+end
+
+---Review tool result before sending to LLM
+---@param result MCPResponseOutput The tool execution result
+---@param metadata {server_name: string, tool_name?: string, uri?: string, action: string} Metadata about the tool/resource
+---@param callback fun(approved: boolean) Callback with user's decision
+function M.review_tool_result(result, metadata, callback)
+    local max_display_lines = 10000 -- Truncate very large results
+
+    -- Don't use async.wrap here since we're already in a callback context
+    vim.schedule(function()
+        if not result then
+            vim.notify("No result to review", vim.log.levels.WARN)
+            return callback(false)
+        end
+
+        -- Track active option (default to "approve")
+        local active_option = "approve"
+
+        -- Function to create footer with current active state
+        local function create_footer()
+            return {
+                { " ", Text.highlights.seamless_border },
+                {
+                    " Approve ",
+                    active_option == "approve" and Text.highlights.button_active or Text.highlights.button_inactive,
+                },
+                { " • ", Text.highlights.seamless_border },
+                {
+                    " Reject ",
+                    active_option == "reject" and Text.highlights.button_active or Text.highlights.button_inactive,
+                },
+                { " ", Text.highlights.seamless_border },
+            }
+        end
+
+        -- Process result into displayable lines
+        local content_lines = {}
+
+        -- Add metadata header
+        table.insert(
+            content_lines,
+            NuiLine():append("Server: ", Text.highlights.muted):append(metadata.server_name, Text.highlights.success)
+        )
+
+        if metadata.tool_name then
+            table.insert(
+                content_lines,
+                NuiLine():append("Tool: ", Text.highlights.muted):append(metadata.tool_name, Text.highlights.info)
+            )
+        elseif metadata.uri then
+            table.insert(
+                content_lines,
+                NuiLine():append("Resource: ", Text.highlights.muted):append(metadata.uri, Text.highlights.link)
+            )
+        end
+
+        table.insert(content_lines, Text.empty_line())
+        table.insert(content_lines, NuiLine():append("━━━ Result ━━━", Text.highlights.muted))
+        table.insert(content_lines, Text.empty_line())
+
+        -- Add result content
+        if result.text and result.text ~= "" then
+            local text_lines = vim.split(result.text, "\n", { plain = true })
+
+            -- Truncate if too large
+            if #text_lines > max_display_lines then
+                local truncated = vim.list_slice(text_lines, 1, max_display_lines)
+                vim.list_extend(truncated, {
+                    "",
+                    string.format("... [Truncated: showing %d of %d lines] ...", max_display_lines, #text_lines),
+                })
+                text_lines = truncated
+            end
+
+            for _, line in ipairs(text_lines) do
+                table.insert(content_lines, NuiLine():append(line, Text.highlights.text))
+            end
+        end
+
+        -- Add image info if present
+        if result.images and #result.images > 0 then
+            table.insert(content_lines, Text.empty_line())
+            table.insert(
+                content_lines,
+                NuiLine():append(
+                    string.format("📷 %d image%s included", #result.images, #result.images > 1 and "s" or ""),
+                    Text.highlights.info
+                )
+            )
+        end
+
+        -- Show error if present
+        if result.isError or result.error then
+            table.insert(content_lines, Text.empty_line())
+            table.insert(content_lines, NuiLine():append("⚠ Error occurred during execution", Text.highlights.error))
+            if result.error then
+                table.insert(content_lines, NuiLine():append(tostring(result.error), Text.highlights.error))
+            end
+        end
+
+        -- Handle empty result
+        if not result.text or result.text == "" and (not result.images or #result.images == 0) then
+            table.insert(content_lines, NuiLine():append("(No text content)", Text.highlights.muted))
+        end
+
+        -- Calculate window dimensions
+        local min_width = 60
+        local max_width = math.min(120, math.floor(vim.o.columns * 0.9))
+        local content_width = 0
+
+        for _, line in ipairs(content_lines) do
+            local line_width = type(line) == "string" and #line or line:width()
+            content_width = math.max(content_width, line_width)
+        end
+
+        local width = math.max(min_width, math.min(max_width, content_width + 4))
+        local max_height = math.floor(vim.o.lines * 0.8)
+        local height = math.min(#content_lines + 3, max_height)
+
+        -- Create buffer and window
+        local bufnr = vim.api.nvim_create_buf(false, true)
+        local ns_id = vim.api.nvim_create_namespace("MCPHubReviewResult")
+
+        -- Render content
+        for i, line in ipairs(content_lines) do
+            if type(line) == "string" then
+                line = Text.pad_line(line)
+            else
+                line = Text.pad_line(line)
+            end
+            line:render(bufnr, ns_id, i)
+        end
+
+        local win_opts = M.get_window_position(width, height)
+        win_opts.style = "minimal"
+        win_opts.border = vim.o.winborder ~= "" and vim.o.winborder
+            or { "╭", "─", "╮", "│", "╯", "─", "╰", "│" }
+        win_opts.title = {
+            { " Tool Result Review ", Text.highlights.header_btn },
+        }
+        win_opts.title_pos = "center"
+        win_opts.footer = create_footer()
+        win_opts.footer_pos = "center"
+
+        local win = vim.api.nvim_open_win(bufnr, true, win_opts)
+
+        -- Window options for scrolling
+        vim.api.nvim_win_set_option(win, "wrap", true)
+        vim.api.nvim_win_set_option(win, "cursorline", true)
+        vim.api.nvim_win_set_option(win, "scrolloff", 5)
+
+        -- Buffer options
+        vim.api.nvim_buf_set_option(bufnr, "modifiable", false)
+        vim.api.nvim_buf_set_option(bufnr, "buftype", "nofile")
+        vim.api.nvim_buf_set_option(bufnr, "swapfile", false)
+        vim.api.nvim_buf_set_option(bufnr, "filetype", "mcphub-review")
+
+        local is_closed = false
+
+        -- Function to update footer
+        local function update_footer()
+            if vim.api.nvim_win_is_valid(win) then
+                local config = vim.api.nvim_win_get_config(win)
+                config.footer = create_footer()
+                vim.api.nvim_win_set_config(win, config)
+            end
+        end
+
+        -- Close function
+        local function close_window(approved)
+            if is_closed then
+                return
+            end
+            is_closed = true
+
+            vim.schedule(function()
+                if vim.api.nvim_win_is_valid(win) then
+                    vim.api.nvim_win_close(win, true)
+                end
+                callback(approved)
+            end)
+        end
+
+        -- Function to execute active option
+        local function execute_active_option()
+            if active_option == "approve" then
+                close_window(true)
+            else -- reject
+                close_window(false)
+            end
+        end
+
+        -- Set up keymaps
+        local keymaps = {
+            -- Direct actions
+            ["y"] = function()
+                close_window(true)
+            end,
+            ["Y"] = function()
+                close_window(true)
+            end,
+            ["a"] = function()
+                close_window(true)
+            end,
+            ["A"] = function()
+                close_window(true)
+            end,
+            ["n"] = function()
+                close_window(false)
+            end,
+            ["N"] = function()
+                close_window(false)
+            end,
+            ["r"] = function()
+                close_window(false)
+            end,
+            ["R"] = function()
+                close_window(false)
+            end,
+            ["<Esc>"] = function()
+                close_window(false)
+            end,
+            ["q"] = function()
+                close_window(false)
+            end,
+            ["<CR>"] = execute_active_option,
+            -- Tab navigation
+            ["<Tab>"] = function()
+                if active_option == "approve" then
+                    active_option = "reject"
+                else
+                    active_option = "approve"
+                end
+                update_footer()
+            end,
+            -- Scrolling
+            ["j"] = function()
+                vim.cmd("normal! j")
+            end,
+            ["k"] = function()
+                vim.cmd("normal! k")
+            end,
+            ["<C-d>"] = function()
+                vim.cmd("normal! \x04") -- Ctrl-D
+            end,
+            ["<C-u>"] = function()
+                vim.cmd("normal! \x15") -- Ctrl-U
+            end,
+            ["gg"] = function()
+                vim.cmd("normal! gg")
+            end,
+            ["G"] = function()
+                vim.cmd("normal! G")
+            end,
+        }
+
+        for key, handler in pairs(keymaps) do
+            vim.keymap.set("n", key, handler, {
+                buffer = bufnr,
+                nowait = true,
+                silent = true,
+                desc = "MCPHub review: " .. key,
+            })
+        end
+
+        -- Auto-close protection
+        local group = vim.api.nvim_create_augroup("MCPHubReview" .. bufnr, { clear = true })
+        vim.api.nvim_create_autocmd({ "WinClosed", "BufWipeout" }, {
+            buffer = bufnr,
+            group = group,
+            callback = function()
+                close_window(false)
+            end,
+            once = true,
+        })
+
+        -- Focus and ensure normal mode
+        vim.api.nvim_set_current_win(win)
+        vim.cmd("stopinsert")
+        vim.cmd("redraw")
+    end)
 end
 
 -- Helper function to determine window positioning
@@ -617,13 +901,6 @@ function M.open_auth_popup(server_name, auth_url)
         end
         if vim.api.nvim_win_is_valid(input_win) then
             vim.api.nvim_win_close(input_win, true)
-        end
-
-        if vim.api.nvim_buf_is_valid(info_buf) then
-            vim.api.nvim_buf_delete(info_buf, { force = true })
-        end
-        if vim.api.nvim_buf_is_valid(input_buf) then
-            vim.api.nvim_buf_delete(input_buf, { force = true })
         end
         -- Return focus to MCPHub window
         if State.ui_instance and State.ui_instance.window then

--- a/tests/test_review_feature.lua
+++ b/tests/test_review_feature.lua
@@ -1,0 +1,723 @@
+-- Tests for "Yes & Review" Tool Approval Feature
+local new_set = MiniTest.new_set
+local expect, eq = MiniTest.expect, MiniTest.expect.equality
+local Helpers = require("tests.helpers")
+
+local T = new_set({
+    hooks = {
+        pre_case = function()
+            _G.child = Helpers.new_child_neovim()
+            _G.child.setup()
+            -- Load required modules in child process using lua_func for type safety
+            _G.child.lua_func(function()
+                _G.ui_utils = require("mcphub.utils.ui")
+                _G.shared = require("mcphub.extensions.shared")
+                _G.State = require("mcphub.state")
+                _G.State.config = require("tests.config")
+            end)
+        end,
+        post_case = function()
+            if _G.child then
+                _G.child.stop()
+                _G.child = nil
+            end
+        end,
+    },
+})
+
+-- =========================================================================
+-- Core UI check
+-- =========================================================================
+
+T["confirm_function_exists_and_returns_three_values"] = function()
+    -- Test that the confirm function exists
+    local result = _G.child.lua_func(function()
+        local ui_utils = require("mcphub.utils.ui")
+        return {
+            has_confirm = type(ui_utils.confirm) == "function",
+        }
+    end)
+
+    eq(result.has_confirm, true)
+end
+
+T["review_window_displays_with_metadata"] = function()
+    -- Start review window in child process
+    _G.child.lua_func(function()
+        local result_data = {
+            text = "This is test output\nfrom a tool execution",
+        }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result = { approved = approved }
+        end)
+
+        vim.wait(100)
+    end)
+
+    -- Check window exists and has content
+    local result = _G.child.lua_func(function()
+        local wins = vim.api.nvim_list_wins()
+        local review_win = nil
+
+        for _, win in ipairs(wins) do
+            local config = vim.api.nvim_win_get_config(win)
+            if config.title and type(config.title) == "table" then
+                local title_str = config.title[1][1]
+                if title_str:match("Review") then
+                    review_win = win
+                    break
+                end
+            end
+        end
+
+        if not review_win then
+            return { has_window = false, line_count = 0, has_server_info = false }
+        end
+
+        local bufnr = vim.api.nvim_win_get_buf(review_win)
+        local buf_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+        -- Check for server info in buffer
+        local has_server_info = false
+        for _, line in ipairs(buf_lines) do
+            if line:match("test_server") then
+                has_server_info = true
+                break
+            end
+        end
+
+        return {
+            has_window = true,
+            line_count = #buf_lines,
+            has_server_info = has_server_info,
+        }
+    end)
+
+    -- Close the review window
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(100)")
+
+    eq(result.has_window, true)
+    eq(result.line_count > 0, true)
+    eq(result.has_server_info, true)
+end
+
+T["review_window_approve_action"] = function()
+    -- Start review window
+    _G.child.lua_func(function()
+        local result_data = { text = "Tool output to approve" }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = { approved = nil }
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    end)
+
+    -- Press 'a' to approve
+    _G.child.type_keys("a")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, true)
+end
+
+T["review_window_reject_action"] = function()
+    -- Start review window
+    _G.child.lua_func(function()
+        local result_data = { text = "Tool output to reject" }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = { approved = nil }
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    end)
+
+    -- Press 'r' to reject
+    _G.child.type_keys("r")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, false)
+end
+
+T["review_window_escape_rejects"] = function()
+    -- Start review window
+    _G.child.lua_func(function()
+        local result_data = { text = "Tool output" }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = { approved = nil }
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    end)
+
+    -- Press Escape (should reject)
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, false)
+end
+
+T["failed_tool_execution_skips_review_window"] = function()
+    -- Simulate tool execution failure with review requested
+    _G.child.lua_func(function()
+        _G.test_result = { review_shown = false, callback_called = false, error_received = nil }
+
+        -- Mock a tool execution that fails
+        local params = {
+            server_name = "test_server",
+            tool_name = "failing_tool",
+            tool_input = {},
+        }
+
+        -- Simulate the flow with review_requested = true but tool execution fails
+        local parsed = _G.shared.parse_params(params, "use_mcp_tool")
+        parsed.review_requested = true
+
+        -- Create a mock callback that tracks if it's called with an error
+        local function mock_callback(result, error)
+            _G.test_result.callback_called = true
+            _G.test_result.error_received = error ~= nil
+
+            -- Check if review window was created
+            local wins = vim.api.nvim_list_wins()
+            for _, win in ipairs(wins) do
+                local config = vim.api.nvim_win_get_config(win)
+                if config.title and type(config.title) == "table" then
+                    local title_str = config.title[1][1]
+                    if title_str:match("Review") then
+                        _G.test_result.review_shown = true
+                        break
+                    end
+                end
+            end
+        end
+
+        -- Simulate error being passed to callback (review should NOT be shown)
+        mock_callback(nil, "Tool execution failed: connection timeout")
+
+        vim.wait(100)
+    end)
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.callback_called, true)
+    eq(result.error_received, true)
+    eq(result.review_shown, false) -- Review window should NOT appear on error
+end
+
+T["review_window_displays_images_count"] = function()
+    _G.child.lua([[
+        local result_data = {
+            text = "Result with images",
+            images = {"image1.png", "image2.png"},
+        }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = {}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved) end)
+
+        vim.wait(100)
+
+        -- Find review window and check for image indicator
+        local wins = vim.api.nvim_list_wins()
+        for _, win in ipairs(wins) do
+            local config = vim.api.nvim_win_get_config(win)
+            if config.title and type(config.title) == "table" then
+                local title_str = config.title[1][1]
+                if title_str:match("Review") then
+                    local bufnr = vim.api.nvim_win_get_buf(win)
+                    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+                    local content = table.concat(lines, "\n")
+                    _G.test_result.has_image_indicator = content:match("2 images") ~= nil or content:match("2 image") ~= nil
+                    break
+                end
+            end
+        end
+    ]])
+
+    -- Close window
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.has_image_indicator, true)
+end
+
+T["review_window_truncates_large_results"] = function()
+    _G.child.lua([[
+        -- Create very large result (over 10,000 lines)
+        local large_text = string.rep("Line of text\n", 15000)
+
+        local result_data = {
+            text = large_text,
+        }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = {}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved) end)
+
+        vim.wait(100)
+
+        -- Check window buffer content
+        local wins = vim.api.nvim_list_wins()
+        for _, win in ipairs(wins) do
+            local config = vim.api.nvim_win_get_config(win)
+            if config.title and type(config.title) == "table" then
+                local title_str = config.title[1][1]
+                if title_str:match("Review") then
+                    local bufnr = vim.api.nvim_win_get_buf(win)
+                    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+                    local content = table.concat(lines, "\n")
+                    _G.test_result.has_truncation = content:match("Truncated") ~= nil
+                    _G.test_result.line_count = #lines
+                    break
+                end
+            end
+        end
+    ]])
+
+    -- Close window
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.has_truncation, true)
+end
+
+T["review_window_scrolling_works"] = function()
+    _G.child.lua([[
+        local large_text = string.rep("Line\n", 100)
+        local result_data = {
+            text = large_text,
+        }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved) end)
+        vim.wait(100)
+    ]])
+
+    -- Try scrolling with j/k
+    _G.child.type_keys("j")
+    _G.child.lua("vim.wait(25)")
+    _G.child.type_keys("k")
+    _G.child.lua("vim.wait(25)")
+
+    -- Try Ctrl-D and Ctrl-U
+    _G.child.type_keys("<C-d>")
+    _G.child.lua("vim.wait(25)")
+    _G.child.type_keys("<C-u>")
+    _G.child.lua("vim.wait(25)")
+
+    -- Close window
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(50)")
+
+    -- No errors occurred
+    eq(true, true)
+end
+
+-- =========================================================================
+-- State Management
+-- =========================================================================
+
+T["parsed_params_includes_review_requested_field"] = function()
+    local result = _G.child.lua_func(function()
+        local params = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            tool_input = { arg1 = "value1" },
+        }
+
+        local parsed = _G.shared.parse_params(params, "use_mcp_tool")
+
+        return {
+            has_field = parsed.review_requested ~= nil,
+            default_value = parsed.review_requested,
+        }
+    end)
+
+    eq(result.has_field, true)
+    eq(result.default_value, false) -- Should default to false
+end
+
+T["auto_approve_function_returns_table_with_review_flag"] = function()
+    local result = _G.child.lua_func(function()
+        -- Set up auto_approve function that returns table
+        _G.State.config.auto_approve = function(params)
+            if params.server_name == "jira" then
+                return { approve = true, review = true }
+            end
+            return false
+        end
+
+        local params = _G.shared.parse_params({
+            server_name = "jira",
+            tool_name = "search_issues",
+            tool_input = {},
+        }, "use_mcp_tool")
+
+        local decision = _G.shared.handle_auto_approval_decision(params)
+
+        return {
+            approved = decision.approve,
+            review_requested = decision.review_requested,
+            has_error = decision.error ~= nil,
+        }
+    end)
+
+    eq(result.approved, true)
+    eq(result.review_requested, true)
+    eq(result.has_error, false)
+end
+
+T["auto_approve_function_boolean_return_no_review"] = function()
+    local result = _G.child.lua_func(function()
+        _G.State.config.auto_approve = function(params)
+            return params.server_name == "filesystem"
+        end
+
+        local params = _G.shared.parse_params({
+            server_name = "filesystem",
+            tool_name = "read_file",
+            tool_input = {},
+        }, "use_mcp_tool")
+
+        local decision = _G.shared.handle_auto_approval_decision(params)
+
+        return {
+            approved = decision.approve,
+            review_requested = decision.review_requested,
+        }
+    end)
+
+    eq(result.approved, true)
+    eq(result.review_requested, false) -- Boolean return shouldn't set review
+end
+
+T["auto_approve_boolean_true_skips_confirmation_and_review"] = function()
+    local result = _G.child.lua_func(function()
+        _G.State.config.auto_approve = true
+
+        local params = _G.shared.parse_params({
+            server_name = "any_server",
+            tool_name = "any_tool",
+            tool_input = {},
+        }, "use_mcp_tool")
+
+        local decision = _G.shared.handle_auto_approval_decision(params)
+
+        return {
+            approved = decision.approve,
+            review_requested = decision.review_requested,
+        }
+    end)
+
+    eq(result.approved, true)
+    eq(result.review_requested, false)
+end
+
+T["servers_json_auto_approve_skips_review"] = function()
+    local result = _G.child.lua_func(function()
+        local params = _G.shared.parse_params({
+            server_name = "approved_server",
+            tool_name = "approved_tool",
+            tool_input = {},
+        }, "use_mcp_tool")
+
+        -- Simulate server-level auto-approval
+        params.is_auto_approved_in_server = true
+
+        local decision = _G.shared.handle_auto_approval_decision(params)
+
+        return {
+            approved = decision.approve,
+            review_requested = decision.review_requested,
+        }
+    end)
+
+    eq(result.approved, true)
+    eq(result.review_requested, false) -- Server auto-approve shouldn't trigger review
+end
+
+-- =========================================================================
+-- Edge Cases
+-- =========================================================================
+
+T["review_empty_result"] = function()
+    _G.child.lua([[
+        local result_data = {
+            text = "",
+        }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = {approved = nil}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    ]])
+
+    -- Should still show window and allow rejection
+    _G.child.type_keys("r")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, false)
+end
+
+T["review_error_result_shows_error_indicator"] = function()
+    _G.child.lua([[
+        local result_data = {
+            text = "Error details",
+            isError = true,
+            error = "Something went wrong",
+        }
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.test_result = {}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved) end)
+
+        vim.wait(100)
+
+        -- Check window shows error indicator
+        local wins = vim.api.nvim_list_wins()
+        for _, win in ipairs(wins) do
+            local config = vim.api.nvim_win_get_config(win)
+            if config.title and type(config.title) == "table" then
+                local title_str = config.title[1][1]
+                if title_str:match("Review") then
+                    local bufnr = vim.api.nvim_win_get_buf(win)
+                    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+                    local content = table.concat(lines, "\n")
+                    _G.test_result.has_error_indicator = content:match("Error occurred") ~= nil
+                    break
+                end
+            end
+        end
+    ]])
+
+    -- Close window
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.has_error_indicator, true)
+end
+
+T["review_nil_result_shows_notification"] = function()
+    _G.child.lua([[
+        _G.test_result = {approved = nil, notification = nil}
+
+        -- Override vim.notify to capture notification
+        local original_notify = vim.notify
+        vim.notify = function(msg, level)
+            _G.test_result.notification = {msg = msg, level = level}
+            return original_notify(msg, level)
+        end
+
+        local metadata = {
+            server_name = "test_server",
+            tool_name = "test_tool",
+            action = "use_mcp_tool",
+        }
+
+        _G.ui_utils.review_tool_result(nil, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+
+        vim.wait(100)
+    ]])
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, false) -- Should reject nil result
+    eq(result.notification ~= nil and result.notification ~= vim.NIL, true) -- Should notify user
+end
+
+T["review_resource_access_displays_uri"] = function()
+    _G.child.lua([[
+        local result_data = {
+            text = "Resource content here",
+        }
+        local metadata = {
+            server_name = "test_server",
+            uri = "file:///test/path",
+            action = "access_mcp_resource",
+        }
+
+        _G.test_result = {}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved) end)
+
+        vim.wait(100)
+
+        -- Check that window shows URI instead of tool name
+        local wins = vim.api.nvim_list_wins()
+        for _, win in ipairs(wins) do
+            local config = vim.api.nvim_win_get_config(win)
+            if config.title and type(config.title) == "table" then
+                local title_str = config.title[1][1]
+                if title_str:match("Review") then
+                    local bufnr = vim.api.nvim_win_get_buf(win)
+                    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+                    local content = table.concat(lines, "\n")
+                    _G.test_result.has_resource = content:match("Resource:") ~= nil
+                    _G.test_result.has_uri = content:match("file:///test/path") ~= nil
+                    break
+                end
+            end
+        end
+    ]])
+
+    -- Close window
+    _G.child.type_keys("<Esc>")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.has_resource, true)
+    eq(result.has_uri, true)
+end
+
+T["auto_approve_error_handling"] = function()
+    local result = _G.child.lua_func(function()
+        -- Set up auto_approve function that throws error
+        _G.State.config.auto_approve = function(params)
+            error("Something went wrong!")
+        end
+
+        local params = _G.shared.parse_params({
+            server_name = "test_server",
+            tool_name = "test_tool",
+            tool_input = {},
+        }, "use_mcp_tool")
+
+        local decision = _G.shared.handle_auto_approval_decision(params)
+
+        return {
+            has_error = decision.error ~= nil,
+            approved = decision.approve,
+            error_message = decision.error,
+        }
+    end)
+
+    eq(result.approved, false)
+    eq(result.has_error, true)
+    eq(result.error_message ~= nil, true)
+end
+
+T["review_keyboard_shortcuts_y_approves"] = function()
+    _G.child.lua([[
+        _G.test_result = {approved = nil}
+        local result_data = {text = "Test output"}
+        local metadata = {server_name = "test", tool_name = "test", action = "use_mcp_tool"}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    ]])
+
+    _G.child.type_keys("y")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, true)
+end
+
+T["review_keyboard_shortcuts_capital_a_approves"] = function()
+    _G.child.lua([[
+        _G.test_result = {approved = nil}
+        local result_data = {text = "Test output"}
+        local metadata = {server_name = "test", tool_name = "test", action = "use_mcp_tool"}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    ]])
+
+    _G.child.type_keys("A")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, true)
+end
+
+T["review_keyboard_shortcuts_n_rejects"] = function()
+    _G.child.lua([[
+        _G.test_result = {approved = nil}
+        local result_data = {text = "Test output"}
+        local metadata = {server_name = "test", tool_name = "test", action = "use_mcp_tool"}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    ]])
+
+    _G.child.type_keys("n")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, false)
+end
+
+T["review_keyboard_shortcuts_q_rejects"] = function()
+    _G.child.lua([[
+        _G.test_result = {approved = nil}
+        local result_data = {text = "Test output"}
+        local metadata = {server_name = "test", tool_name = "test", action = "use_mcp_tool"}
+        _G.ui_utils.review_tool_result(result_data, metadata, function(approved)
+            _G.test_result.approved = approved
+        end)
+        vim.wait(100)
+    ]])
+
+    _G.child.type_keys("q")
+    _G.child.lua("vim.wait(100)")
+
+    local result = _G.child.lua_get("_G.test_result")
+    eq(result.approved, false)
+end
+
+return T


### PR DESCRIPTION
## Description

In my dayjob I am allowed to use Github Copilot and other chat tools to enrich my developer experience. Some employers are okay with me using Jira & Concluence MCPs, but I don't like using them.

When i ask confluence "The first feature" then the Confluence API will perform a search for "The first feature", but also "The", "first" or "feature", which can drag in IP or even insider trading stuff that I'd rather not share with an internet based LLM.

With this pull request I'm adding more granular control over tool execution. When a tool is executed a new option is available "yes & review". when this option is picked, then the tool will execute like normal, but show a window to the user prompting them to read through the text that is going to be fed back to the LLM. if the user is not comfortable with the result returned (or if the result returned would steer the LLM into the wrong direction; or worse includes rather clear prompt poisoning/injection ) then the user can simply just reject the returned result and it will never be fed into the LLM.

Tests are now done. i figure some of the docs / tests / logic could be dragged around, but I'll wait for review first. 

## Related Issue(s)

No related issues

## Screenshots

Video demo:

https://youtu.be/pBM-lF-RhrQ

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages