### PR TITLE
fix: rename config node

### DIFF
--- a/lua/mcphub/extensions/codecompanion/variables.lua
+++ b/lua/mcphub/extensions/codecompanion/variables.lua
@@ -14,10 +14,7 @@ function M.register(opts)
         return
     end
 
-    local cc_variables = config.interactions.chat.variables
-    if cc_variables == nil then
-        cc_variables = {}
-    end
+    local cc_variables = config.interactions.chat.editor_context
 
     -- Remove existing MCP variables
     for key, value in pairs(cc_variables) do

--- a/lua/mcphub/extensions/codecompanion/variables.lua
+++ b/lua/mcphub/extensions/codecompanion/variables.lua
@@ -15,6 +15,9 @@ function M.register(opts)
     end
 
     local cc_variables = config.interactions.chat.variables
+    if cc_variables == nil then
+      cc_variables = {}
+    end
 
     -- Remove existing MCP variables
     for key, value in pairs(cc_variables) do

--- a/lua/mcphub/extensions/codecompanion/variables.lua
+++ b/lua/mcphub/extensions/codecompanion/variables.lua
@@ -16,7 +16,7 @@ function M.register(opts)
 
     local cc_variables = config.interactions.chat.variables
     if cc_variables == nil then
-      cc_variables = {}
+        cc_variables = {}
     end
 
     -- Remove existing MCP variables


### PR DESCRIPTION
## Description

After merging of [PR](https://github.com/olimorris/codecompanion.nvim/pull/2719) to codecompanion.nvim the `interactions.chat.variables` does not exist anymore and should be replaced by `interactions.chat.editor_context`

## Related Issue(s)

https://github.com/ravitemer/mcphub.nvim/issues/275

## Screenshots

<img width="1285" height="130" alt="image" src="https://github.com/user-attachments/assets/991f7580-4fad-4ea8-b1f4-431af9561298" />


## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [x] I've updated the README and/or relevant docs pages
- [x] I've run `make test` to ensure all tests pass
- [x] I've run `make format` to format the code
- [x] I've run `make docs` to update the vimdoc pages
