### PR TITLE
feat(extensions): adapt CodeCompanion extension for v19 compatibility

### DIFF
--- a/lua/mcphub/extensions/codecompanion/slash_commands.lua
+++ b/lua/mcphub/extensions/codecompanion/slash_commands.lua
@@ -14,9 +14,8 @@ function M.register()
     local slash_commands = config.interactions.chat.slash_commands
 
     -- Remove existing MCP slash commands
-    for key, value in pairs(slash_commands) do
-        local id = value.id or ""
-        if id:sub(1, 3) == "mcp" then
+    for key, _ in pairs(slash_commands) do
+        if type(key) == "string" and key:sub(1, 4) == "mcp:" then
             slash_commands[key] = nil
         end
     end
@@ -41,7 +40,6 @@ function M.register()
         end
 
         slash_commands["mcp:" .. prompt_name] = {
-            id = "mcp" .. server_name .. prompt_name,
             description = description,
             callback = function(self)
                 shared.collect_arguments(arguments, function(values)
@@ -92,10 +90,9 @@ function M.register()
 
                         -- Handle images
                         if output.images and #output.images > 0 then
-                            local helpers = require("codecompanion.interactions.chat.helpers")
                             for _, image in ipairs(output.images) do
                                 local id = string.format("mcp-%s", os.time())
-                                helpers.add_image(self, {
+                                self:add_image_message({
                                     id = id,
                                     base64 = image.data,
                                     mimetype = image.mimeType,

--- a/lua/mcphub/extensions/codecompanion/variables.lua
+++ b/lua/mcphub/extensions/codecompanion/variables.lua
@@ -14,7 +14,7 @@ function M.register(opts)
         return
     end
 
-    local cc_editor_context = config.interactions.chat.editor_context
+    local cc_editor_context = config.config.interactions.shared.editor_context
 
     -- Remove existing MCP editor context entries
     for key, _ in pairs(cc_editor_context) do


### PR DESCRIPTION
## Summary

Migrate the CodeCompanion extension to support CodeCompanion v19's breaking API changes while maintaining the same user-facing behavior.

## Motivation

CodeCompanion v19 introduced several breaking changes to its tool, variable, and image APIs. This PR updates all four CodeCompanion extension modules to work with the new API surface.

## Changes

### Tool Config Structure (`tools.lua`)
- `callback = { table }` → `callback = function() return { table } end`
- v19's `Tools.resolve()` requires `callback` to be a function, not a table.

### Tool `cmds` Handlers (`tools.lua`, `core.lua`)
- Handler signature: `(agent, args, _, output_handler)` → `(self, action, opts)`
- Output callback now accessed via `opts.output_cb` instead of the 4th positional arg.

### Tool Output Handlers (`core.lua`)
- Success/error signature: `(self, agent, cmd, data)` → `(self, data, meta)`
- Chat object accessed via `meta.tools.chat` instead of the `agent` parameter.

### Variables → Editor Context (`variables.lua`)
- `config.interactions.chat.variables` → `config.interactions.chat.editor_context`
- Cleanup logic now uses key prefix (`mcp:`) instead of the custom `id` field.
- Removed unused `id` field from registrations.

### Image Handling (`variables.lua`, `slash_commands.lua`)
- `require("codecompanion.interactions.chat.helpers").add_image(chat, img)` → `chat:add_image_message(img)`
- All references to the removed `helpers` module have been eliminated.

### Group System Prompts (`tools.lua`)
- `system_prompt = function(self)` → `system_prompt = function(group_config, ctx)`
- Updated all three system_prompt functions (static group, individual tools, dynamic server groups).

## Files Modified
- `lua/mcphub/extensions/codecompanion/tools.lua`
- `lua/mcphub/extensions/codecompanion/core.lua`
- `lua/mcphub/extensions/codecompanion/variables.lua`
- `lua/mcphub/extensions/codecompanion/slash_commands.lua`

## Testing
- All 135 existing tests pass (`make test`)
- Code formatted with `stylua` (`make format`)
- No CodeCompanion-specific integration tests exist in the repo currently; changes were verified by tracing the v19 source code for each API contract.