### PR TITLE
fix(codecompanion): handle both interactions and strategies config schemas in variables registration

### DIFF
--- a/lua/mcphub/extensions/codecompanion/variables.lua
+++ b/lua/mcphub/extensions/codecompanion/variables.lua
@@ -14,7 +14,11 @@ function M.register(opts)
         return
     end
 
-    local cc_variables = config.interactions.chat.variables
+    local cc_variables = (config.interactions and config.interactions.chat and config.interactions.chat.variables)
+        or (config.strategies and config.strategies.chat and config.strategies.chat.variables)
+    if not cc_variables then
+        return
+    end
 
     -- Remove existing MCP variables
     for key, value in pairs(cc_variables) do


### PR DESCRIPTION
## Problem

When using CodeCompanion v13+, the config schema changed from
`interactions.chat.variables` to `strategies.chat.variables`. The
`variables.lua` extension assumed the old `interactions` path existed,
causing a nil-index error and preventing variable registration from completing.

## Fix

Add a fallback that checks both config paths, and return early if neither
exists rather than erroring. This makes the code forward- and
backward-compatible across CodeCompanion config versions.

## Changes

- `lua/mcphub/extensions/codecompanion/variables.lua`: check both
  `config.interactions.chat.variables` and `config.strategies.chat.variables`,
  return early if neither is present.