### PR TITLE
fix(codecompanion): support editor_context backend for MCP resource vars

### DIFF
--- a/lua/mcphub/extensions/codecompanion/variables.lua
+++ b/lua/mcphub/extensions/codecompanion/variables.lua
@@ -1,6 +1,149 @@
 local M = {}
 local mcphub = require("mcphub")
 
+---@param tbl table|nil
+local function cleanup_mcp_items(tbl)
+    if type(tbl) ~= "table" then
+        return
+    end
+
+    for key, value in pairs(tbl) do
+        if type(value) == "table" then
+            local id = value.id or ""
+            if id:sub(1, 3) == "mcp" then
+                tbl[key] = nil
+            end
+        end
+    end
+end
+
+---@param hub MCPHub.Instance
+---@param server_name string
+---@param uri string
+---@return function
+local function make_resource_callback(hub, server_name, uri)
+    return function(self)
+        -- Sync call - blocks UI (can't use async in variables/editor_context yet)
+        local result = hub:access_resource(server_name, uri, {
+            caller = {
+                type = "codecompanion",
+                codecompanion = self,
+                meta = {
+                    is_within_variable = true,
+                },
+            },
+            parse_response = true,
+        })
+
+        if not result then
+            return string.format("Accessing resource failed: %s", uri)
+        end
+
+        -- Handle images
+        if result.images and #result.images > 0 then
+            local helpers = require("codecompanion.interactions.chat.helpers")
+            local chat = self and (self.Chat or self)
+
+            if chat then
+                for _, image in ipairs(result.images) do
+                    local id = string.format("mcp-%s", os.time())
+                    helpers.add_image(chat, {
+                        id = id,
+                        base64 = image.data,
+                        mimetype = image.mimeType,
+                    })
+                end
+            end
+        end
+
+        return result.text
+    end
+end
+
+---@param resources table
+---@param target table
+---@param hub MCPHub.Instance
+---@return string[]
+local function register_legacy_variables(resources, target, hub)
+    cleanup_mcp_items(target)
+
+    local added_resources = {}
+
+    for _, resource in ipairs(resources) do
+        local server_name = resource.server_name
+        local uri = resource.uri
+        local resource_name = resource.name or uri
+        local description = resource.description or ""
+        description = description:gsub("\n", " ")
+        description = resource_name .. " (" .. description .. ")"
+
+        local var_id = "mcp:" .. uri
+        target[var_id] = {
+            id = "mcp" .. server_name .. uri,
+            description = description,
+            hide_in_help_window = true,
+            callback = make_resource_callback(hub, server_name, uri),
+        }
+
+        table.insert(added_resources, var_id)
+    end
+
+    return added_resources
+end
+
+---@param resources table
+---@param target table
+---@param hub MCPHub.Instance
+---@return string[]
+local function register_editor_context(resources, target, hub)
+    cleanup_mcp_items(target)
+
+    local added_resources = {}
+
+    for _, resource in ipairs(resources) do
+        local server_name = resource.server_name
+        local uri = resource.uri
+        local resource_name = resource.name or uri
+        local description = resource.description or ""
+        description = description:gsub("\n", " ")
+        description = resource_name .. " (" .. description .. ")"
+
+        local var_id = "mcp:" .. uri
+        target[var_id] = {
+            id = "mcp" .. server_name .. uri,
+            description = description,
+            hide_in_help_window = true,
+            callback = make_resource_callback(hub, server_name, uri),
+        }
+
+        table.insert(added_resources, var_id)
+    end
+
+    return added_resources
+end
+
+---@param config table
+---@return string|nil, table|nil
+local function get_backend(config)
+    local interactions = config.interactions or {}
+    local chat = interactions.chat or {}
+    local shared = interactions.shared or {}
+
+    if type(chat.variables) == "table" then
+        return "variables", chat.variables
+    end
+
+    if type(shared.editor_context) == "table" then
+        return "editor_context", shared.editor_context
+    end
+
+    if type(chat.editor_context) == "table" then
+        return "editor_context", chat.editor_context
+    end
+
+    return nil, nil
+end
+
 ---@param opts MCPHub.Extensions.CodeCompanionConfig
 function M.register(opts)
     local hub = mcphub.get_hub_instance()
@@ -14,69 +157,27 @@ function M.register(opts)
         return
     end
 
-    local cc_variables = config.interactions.chat.variables
-
-    -- Remove existing MCP variables
-    for key, value in pairs(cc_variables) do
-        local id = value.id or ""
-        if id:sub(1, 3) == "mcp" then
-            cc_variables[key] = nil
-        end
+    local backend, target = get_backend(config)
+    if not backend or not target then
+        vim.notify(
+            "MCPHub: no compatible CodeCompanion resource registration backend found",
+            vim.log.levels.WARN,
+            { title = "MCPHub" }
+        )
+        return
     end
 
     local added_resources = {}
-    -- Add current resources as variables
-    for _, resource in ipairs(resources) do
-        local server_name = resource.server_name
-        local uri = resource.uri
-        local resource_name = resource.name or uri
-        local description = resource.description or ""
-        description = description:gsub("\n", " ")
-        description = resource_name .. " (" .. description .. ")"
-        local var_id = "mcp:" .. uri
-        cc_variables[var_id] = {
-            id = "mcp" .. server_name .. uri,
-            description = description,
-            hide_in_help_window = true,
-            callback = function(self)
-                -- Sync call - blocks UI (can't use async in variables yet)
-                local result = hub:access_resource(server_name, uri, {
-                    caller = {
-                        type = "codecompanion",
-                        codecompanion = self,
-                        meta = {
-                            is_within_variable = true,
-                        },
-                    },
-                    parse_response = true,
-                })
 
-                if not result then
-                    return string.format("Accessing resource failed: %s", uri)
-                end
-
-                -- Handle images
-                if result.images and #result.images > 0 then
-                    local helpers = require("codecompanion.interactions.chat.helpers")
-                    for _, image in ipairs(result.images) do
-                        local id = string.format("mcp-%s", os.time())
-                        helpers.add_image(self.Chat, {
-                            id = id,
-                            base64 = image.data,
-                            mimetype = image.mimeType,
-                        })
-                    end
-                end
-
-                return result.text
-            end,
-        }
-        table.insert(added_resources, var_id)
+    if backend == "variables" then
+        added_resources = register_legacy_variables(resources, target, hub)
+    elseif backend == "editor_context" then
+        added_resources = register_editor_context(resources, target, hub)
     end
 
-    -- Update syntax highlighting for variables
     M.update_variable_syntax(added_resources)
 end
+
 -- Setup MCP resources as CodeCompanion variables
 ---@param opts MCPHub.Extensions.CodeCompanionConfig
 function M.setup(opts)


### PR DESCRIPTION
## Description

This PR fixes CodeCompanion v19 compatibility for MCP resource variables in `mcphub.nvim`.

### Root cause

`mcphub.nvim` assumed `config.interactions.chat.variables` always exists.  
On CodeCompanion v19, this table can be missing, which causes a startup crash when `make_vars = true` (`pairs()` called on `nil`).

### What this changes

- Adds runtime backend detection for resource variable registration:
  - `config.interactions.chat.variables` (legacy backend)
  - `config.interactions.shared.editor_context` (CodeCompanion v19+ backend)
  - `config.interactions.chat.editor_context` (fallback)
- Preserves existing user-facing identifiers and syntax:
  - `#{mcp:...}`
- Keeps backward compatibility with older CodeCompanion layouts.

## Related Issue(s)

- Fixes #275
- Fixes #278

## Screenshots

N/A (no UI changes)

## Checklist

- [x] I've read the [contributing](https://github.com/ravitemer/mcphub.nvim/blob/main/CONTRIBUTING.md) guidelines and have adhered to them in this PR
- [ ] I've updated the README and/or relevant docs pages (N/A: no documentation source changes)
- [ ] I've run `make test` to ensure all tests pass (see Notes)
- [ ] I've run `make format` to format the code (see Notes)
- [ ] I've run `make docs` to update the vimdoc pages (N/A: no documentation source changes)

## Notes

- `make format` fails locally in pre-existing/unrelated files (outside this PR), due to parser errors around `continue` labels.
- `make test` fails locally in an unrelated baseline test:
  - `tests/native/neovim/files/edit_file/test_edit_ui.lua | reject_all_functionality`
  - `Can not use child.lua_func because child process is blocked`
- The failure is outside files changed by this PR.
- The modified file in this PR is:
  - `lua/mcphub/extensions/codecompanion/variables.lua`
